### PR TITLE
webpack dependency needed to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "sass-loader": "^3.1.2",
     "sass-variable-loader": "^0.0.3",
     "style-loader": "^0.13.0",
-    "svg-icon-template-loader": "0.0.4"
+    "svg-icon-template-loader": "0.0.4",
+    "webpack": "^1.12.13"
   }
 }


### PR DESCRIPTION
You need webpack as a dependency to actually build the project. Unless you have it installed globally, which you shouldn't.