### PR TITLE
Ratio bar fixes

### DIFF
--- a/src/components/ratio-bar/ratio-bar.jsx
+++ b/src/components/ratio-bar/ratio-bar.jsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import './ratio-bar.scss';
 
 function percentage(value, total) {
-  return Math.round((value / total) * 1000) / 10;
+  return (value / total) * 100;
 }
 
 function calculatePercentages(data) {
@@ -42,15 +42,14 @@ function calculatePercentages(data) {
   ];
 }
 
-function renderBar(direction, value) {
+function renderBar(direction, value, naturalLanguage) {
+  if (value <= 0.01) { // Don't render any bar if it's insignificant
+    return null;
+  }
+
   const classes = classNames('ratio-bar__bar', `ratio-bar__bar--${direction}`);
   const styles = {
     width: `${value}%`,
-  };
-  const naturalLanguage = {
-    positive: 'up',
-    neutral: 'with no change',
-    negative: 'down',
   };
 
   return (

--- a/src/components/ratio-bar/ratio-bar.jsx
+++ b/src/components/ratio-bar/ratio-bar.jsx
@@ -43,45 +43,41 @@ function calculatePercentages(data) {
 }
 
 function renderBar(direction, value, naturalLanguage) {
-  if (value <= 0.01) { // Don't render any bar if it's insignificant
-    return null;
-  }
-
   const classes = classNames('ratio-bar__bar', `ratio-bar__bar--${direction}`);
   const styles = {
     width: `${value}%`,
   };
 
   return (
-    <span className={ classes } style={ styles }>
+    <div className={ classes } style={ styles }>
       <span className="ratio-bar__bar-background">
         { `${value.toFixed(2)}% ${naturalLanguage[direction]}.` }
       </span>
-    </span>
+    </div>
   );
 }
 
-function renderLabels(show, labelUp, labelDown) {
+function renderLabels(show, labelPositive, labelNegative) {
   if (!show) {
     return <span />;
   }
 
   return (
     <div aria-hidden="true">
-      <span className="ratio-bar__direction-label ratio-bar__direction-label--negative">{ labelDown }</span>
-      <span className="ratio-bar__direction-label ratio-bar__direction-label--positive">{ labelUp }</span>
+      <span className="ratio-bar__direction-label ratio-bar__direction-label--negative">{ labelNegative }</span>
+      <span className="ratio-bar__direction-label ratio-bar__direction-label--positive">{ labelPositive }</span>
     </div>
   );
 }
 
-function RatioBar({ data, label, labelUp, labelDown, showLabels, className, ...rest }) {
+function RatioBar({ data, label, labelPositive, labelNeutral, labelNegative, showLabels, className, ...rest }) {
   const classes = classNames('ratio-bar', className);
   const [positive, neutral, negative] = calculatePercentages(data);
 
   const naturalLanguage = {
-    positive: labelUp.toLowerCase(),
-    neutral: 'with no change',
-    negative: labelDown.toLowerCase(),
+    positive: labelPositive.toLowerCase(),
+    neutral: labelNeutral.toLowerCase(),
+    negative: labelNegative.toLowerCase(),
   };
 
   return (
@@ -90,7 +86,7 @@ function RatioBar({ data, label, labelUp, labelDown, showLabels, className, ...r
       { renderBar('negative', negative, naturalLanguage) }
       { renderBar('neutral', neutral, naturalLanguage) }
       { renderBar('positive', positive, naturalLanguage) }
-      { renderLabels(showLabels, labelUp, labelDown) }
+      { renderLabels(showLabels, labelPositive, labelNegative) }
     </div>
   );
 }
@@ -103,14 +99,16 @@ RatioBar.propTypes = {
   label: PropTypes.string,
   className: PropTypes.string,
   showLabels: PropTypes.bool,
-  labelUp: PropTypes.string,
-  labelDown: PropTypes.string,
+  labelPositive: PropTypes.string,
+  labelNeutral: PropTypes.string,
+  labelNegative: PropTypes.string,
 };
 
 RatioBar.defaultProps = {
   showLabels: true,
-  labelUp: 'Up',
-  labelDown: 'Down',
+  labelPositive: 'Up',
+  labelNeutral: 'with no change',
+  labelNegative: 'Down',
 };
 
 export default RatioBar;

--- a/src/components/ratio-bar/ratio-bar.jsx
+++ b/src/components/ratio-bar/ratio-bar.jsx
@@ -55,36 +55,42 @@ function renderBar(direction, value, naturalLanguage) {
   return (
     <span className={ classes } style={ styles }>
       <span className="ratio-bar__bar-background">
-        { `${value}% ${naturalLanguage[direction]}.` }
+        { `${value.toFixed(2)}% ${naturalLanguage[direction]}.` }
       </span>
     </span>
   );
 }
 
-function renderLabels(show) {
+function renderLabels(show, labelUp, labelDown) {
   if (!show) {
     return <span />;
   }
 
   return (
     <div aria-hidden="true">
-      <span className="ratio-bar__direction-label ratio-bar__direction-label--negative">Down</span>
-      <span className="ratio-bar__direction-label ratio-bar__direction-label--positive">Up</span>
+      <span className="ratio-bar__direction-label ratio-bar__direction-label--negative">{ labelDown }</span>
+      <span className="ratio-bar__direction-label ratio-bar__direction-label--positive">{ labelUp }</span>
     </div>
   );
 }
 
-function RatioBar({ data, label, showLabels, className, ...rest }) {
+function RatioBar({ data, label, labelUp, labelDown, showLabels, className, ...rest }) {
   const classes = classNames('ratio-bar', className);
   const [positive, neutral, negative] = calculatePercentages(data);
+
+  const naturalLanguage = {
+    positive: labelUp.toLowerCase(),
+    neutral: 'with no change',
+    negative: labelDown.toLowerCase(),
+  };
 
   return (
     <div className={ classes } { ...rest }>
       { label ? <span className="ratio-bar__label">{ label }</span> : <span /> }
-      { renderBar('negative', negative) }
-      { renderBar('neutral', neutral) }
-      { renderBar('positive', positive) }
-      { renderLabels(showLabels) }
+      { renderBar('negative', negative, naturalLanguage) }
+      { renderBar('neutral', neutral, naturalLanguage) }
+      { renderBar('positive', positive, naturalLanguage) }
+      { renderLabels(showLabels, labelUp, labelDown) }
     </div>
   );
 }
@@ -97,10 +103,14 @@ RatioBar.propTypes = {
   label: PropTypes.string,
   className: PropTypes.string,
   showLabels: PropTypes.bool,
+  labelUp: PropTypes.string,
+  labelDown: PropTypes.string,
 };
 
 RatioBar.defaultProps = {
   showLabels: true,
+  labelUp: 'Up',
+  labelDown: 'Down',
 };
 
 export default RatioBar;

--- a/src/components/ratio-bar/ratio-bar.scss
+++ b/src/components/ratio-bar/ratio-bar.scss
@@ -10,24 +10,18 @@
     display: block;
     font-size: 1.4rem;
     color: $color-text-muted;
-    padding-bottom: rem(4px);
+    padding: rem(0 1px 4px 1px);
   }
 
   &__bar {
     display: inline-block;
     height: rem(16px);
-
-    &:before {
-      width: rem(2px);
-      background: $color-base;
-      height: rem(16px);
-      content: ' ';
-      position: absolute;
-    }
+    text-align: center;
 
     &-background {
-      display: block;
+      display: inline-block;
       width: 100%;
+      width: calc(100% - #{rem(2px)});
       height: 100%;
     }
 
@@ -56,7 +50,7 @@
   &__direction-label {
     display: inline-block;
     font-size: rem(14px);
-    padding-top: rem(4px);
+    padding: rem(4px 1px 0 1px);
     width: 50%;
 
     &--negative {

--- a/src/components/ratio-bar/ratio-bar.scss
+++ b/src/components/ratio-bar/ratio-bar.scss
@@ -16,12 +16,18 @@
   &__bar {
     display: inline-block;
     height: rem(16px);
-    padding: rem(0 1px);
+
+    &:before {
+      width: rem(2px);
+      background: $color-base;
+      height: rem(16px);
+      content: ' ';
+      position: absolute;
+    }
 
     &-background {
       display: block;
       width: 100%;
-      // min-width: rem(1px);
       height: 100%;
     }
 

--- a/src/components/select/select.jsx
+++ b/src/components/select/select.jsx
@@ -2,6 +2,6 @@ import React from 'react';
 import ReactSelect from 'react-select';
 import './select.scss';
 
-const Select = (props) => <ReactSelect {...props} />;
+const Select = (props) => <ReactSelect { ...props } />;
 
 export default Select;

--- a/test/components/ratio-bar/ratio-bar.test.js
+++ b/test/components/ratio-bar/ratio-bar.test.js
@@ -16,19 +16,21 @@ describe('<RatioBar />', () => {
     change: -1,
   }];
 
+  const widthPercent = `${(1 / 3) * 100}%`;
+
   beforeEach(() => {
     component = shallow(<RatioBar data={ data } />);
   });
 
-  it('positive bar should have a width of 33.3%', () => {
-    expect(component.find('.ratio-bar__bar--positive').prop('style').width).to.equal('33.3%');
+  it(`positive bar should have a width of ${widthPercent}`, () => {
+    expect(component.find('.ratio-bar__bar--positive').prop('style').width).to.equal(widthPercent);
   });
 
-  it('neutral bar should have a width of 33.3%', () => {
-    expect(component.find('.ratio-bar__bar--neutral').prop('style').width).to.equal('33.3%');
+  it(`neutral bar should have a width of ${widthPercent}`, () => {
+    expect(component.find('.ratio-bar__bar--neutral').prop('style').width).to.equal(widthPercent);
   });
 
-  it('negative bar should have a width of 33.3%', () => {
-    expect(component.find('.ratio-bar__bar--negative').prop('style').width).to.equal('33.3%');
+  it(`negative bar should have a width of ${widthPercent}`, () => {
+    expect(component.find('.ratio-bar__bar--negative').prop('style').width).to.equal(widthPercent);
   });
 });


### PR DESCRIPTION
* Fixes issues where the bars got "unfortunate" widths (∑`widths` > 100%) and therefore overflowed to the next line.
* Adds `labelUp` and `labelDown` so that we can send in translations there.