### PR TITLE
Bump react-select to avoid prop warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "react-input-autosize": "^0.6.13",
     "react-prop-types": "^0.3.0",
     "react-pure-render": "^1.0.2",
-    "react-select": "^1.0.0-beta13",
+    "react-select": "^1.0.0-beta14",
     "react-svg-sprite-icon": "^0.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
To avoid errors like these with newer React versions:
```
Warning: Unknown prop `minWidth` on <input> tag. Remove this prop from the element. For details, see https://fb.me/react-unknown-prop
    in input (created by AutosizeInput)
    in div (created by AutosizeInput)
    in AutosizeInput (created by Select)
    in div (created by Select)
    in div (created by Select)
    in Select (created by Select)
    in Select (created by AccountSelector)
    in div
    in Col (created by AccountSelector)
    in AccountSelector (created by Connect(AccountSelector))
    in Connect(AccountSelector) (created by App)
    in div
    in Row (created by App)
    in div
    in Grid (created by App)
    in div (created by App)
    in App (created by Connect(App))
    in Connect(App) (created by IntlProviderApp)
    in IntlProvider (created by IntlProviderApp)
    in IntlProviderApp (created by Root)
    in Provider (created by Root)
    in Root
```