### PR TITLE
removed minrange config for xaxis

### DIFF
--- a/src/components/graph/themes/base.js
+++ b/src/components/graph/themes/base.js
@@ -145,7 +145,6 @@ export default {
     offset: 0,
     tickColor: '#ffffff',
     tickPosition: 'inside',
-    minRange: 900000,
     lineWidth: 1,
     tickPixelInterval: 130,
     tickWidth: 2,


### PR DESCRIPTION
This setting lets you decide how much you can zoom. The highcharts default way of calculating a good min range is working fine and therefore this value shouldn't be set. 