### PR TITLE
Add a muted variant for Graph theme and RangeSelector

### DIFF
--- a/src/components/graph/graph.jsx
+++ b/src/components/graph/graph.jsx
@@ -1,10 +1,17 @@
 import React, { PropTypes } from 'react';
 import ReactHighstocks from 'react-highcharts/dist/ReactHighstock';
 import merge from 'lodash.merge';
-import { baseTheme, lightTheme, darkTheme } from './themes';
+import { baseTheme, lightTheme, darkTheme, mutedTheme } from './themes';
 import RangeSelector from '../range-selector/';
 import dateMath from 'date-arithmetic';
 import './graph.scss';
+
+const counts = {
+  '1m': 30,
+  '3m': 90,
+  '6m': 180,
+  '1y': 365,
+};
 
 class Graph extends React.Component {
   constructor(props) {
@@ -13,7 +20,7 @@ class Graph extends React.Component {
     this.setZoom = this.setZoom.bind(this);
   }
 
-  setZoom({ type, count }) {
+  setZoom({ type }) {
     const chart = this.chart.getChart();
     const { max, dataMin, dataMax } = chart.xAxis[0];
 
@@ -28,7 +35,7 @@ class Graph extends React.Component {
         break;
       default:
         chart.xAxis[0].setExtremes(
-          dateMath.startOf(dateMath.subtract(max, count, type), 'day').getTime()
+          dateMath.startOf(dateMath.subtract(max, counts[type] || 30, 'day'), 'day').getTime()
         , max);
     }
   }
@@ -39,6 +46,8 @@ class Graph extends React.Component {
         return merge({}, other, lightTheme, config);
       case 'dark':
         return merge({}, other, darkTheme, config);
+      case 'muted':
+        return merge({}, other, mutedTheme, config);
       default:
         return merge({}, other, baseTheme, config);
     }
@@ -71,7 +80,7 @@ Graph.defaultProps = {
 
 Graph.propTypes = {
   /** Theme variant of the chart. */
-  variant: PropTypes.oneOf(['light', 'dark']),
+  variant: PropTypes.oneOf(['light', 'dark', 'muted']),
   /** Highstocks config object, overrides default themes per setting, see API documentation [here](http://api.highcharts.com/highstock). */
   config: PropTypes.object,
 };

--- a/src/components/graph/graph.md
+++ b/src/components/graph/graph.md
@@ -1,4 +1,4 @@
-The UI kit exports two themes for highcharts and a base theme for easy overriding as well as a RangeSelector component.
+The UI kit exports three themes for highcharts and a base theme for easy overriding as well as a RangeSelector component.
 
     const { data } = require('./data.js');
 

--- a/src/components/graph/graph.md
+++ b/src/components/graph/graph.md
@@ -50,6 +50,12 @@ The UI kit exports two themes for highcharts and a base theme for easy overridin
 
       <Graph
         name="graph"
+        variant="muted"
+        config={ config }
+      />
+
+      <Graph
+        name="graph"
         variant="light"
         config={ configAlt }
       />

--- a/src/components/graph/themes/base.js
+++ b/src/components/graph/themes/base.js
@@ -128,6 +128,7 @@ export default {
       },
       y: 4,
     },
+    showFirstLabel: false,
     gridLineColor: '#ededed',
     gridZIndex: 1,
     gridLineWidth: 1,

--- a/src/components/graph/themes/index.js
+++ b/src/components/graph/themes/index.js
@@ -2,9 +2,11 @@ import merge from 'lodash.merge';
 import base from './base';
 import light from './light';
 import dark from './dark';
+import muted from './muted';
 
 module.exports = {
   baseTheme: base,
   lightTheme: merge({}, base, light),
   darkTheme: merge({}, base, dark),
+  mutedTheme: merge({}, base, muted),
 };

--- a/src/components/graph/themes/muted.js
+++ b/src/components/graph/themes/muted.js
@@ -50,10 +50,10 @@ export default {
     column: {
       borderWidth: 1,
       borderColor: 'rgba(255, 255, 255, 0)',
-      color: variables.colorBlack,
+      color: variables.colorGrayDarker,
       states: {
         hover: {
-          borderColor: variables.colorBlack,
+          borderColor: variables.colorGrayDarker,
           color: variables.colorBase,
         },
       },
@@ -125,4 +125,10 @@ export default {
       color: chroma.mix(variables.colorBase, variables.colorGrayDarker, 0.7).css(),
     },
   }],
+
+  noData: {
+    style: {
+      color: variables.colorGrayDarker,
+    },
+  },
 };

--- a/src/components/graph/themes/muted.js
+++ b/src/components/graph/themes/muted.js
@@ -3,34 +3,35 @@ import chroma from 'chroma-js';
 import hlc from '../hlc';
 
 const tickLabelStyle = {
-  color: variables.colorBase,
+  color: variables.colorGrayDarker,
   fontSize: '10px',
-  textShadow: '0 1px 1px rgba(0, 0, 0, .3)',
+  textShadow: 'none',
   fontWeight: '600',
 };
 
 export default {
   navigator: {
-    outlineColor: chroma.mix(variables.colorBase, variables.colorInfo, 0.3).css(),
+    outlineColor: chroma.mix(variables.colorBase, variables.colorGrayDarker, 0.7).css(),
     series: {
       color: '#fff',
     },
     xAxis: {
-      gridLineColor: chroma(variables.colorBase).alpha(0.3).css(),
+      gridLineColor: chroma(variables.colorGrayDark).alpha(0.3).css(),
       labels: {
         align: 'center',
         style: tickLabelStyle,
       },
     },
     handles: {
-      backgroundColor: chroma.mix(variables.colorBase, variables.colorInfo, 0.7).css(),
-      borderColor: variables.colorBase,
+      backgroundColor: variables.colorGray,
+      borderColor: variables.colorGrayDarker,
     },
+    maskFill: chroma(variables.colorGrayDark).alpha(0.15).css(),
   },
 
   chart: {
     zoomType: 'x',
-    backgroundColor: variables.colorInfo,
+    backgroundColor: variables.colorGrayLight,
     events: {
       redraw: hlc,
     },
@@ -49,18 +50,18 @@ export default {
     column: {
       borderWidth: 1,
       borderColor: 'rgba(255, 255, 255, 0)',
-      color: 'rgba(255, 255, 255, 1)',
+      color: variables.colorBlack,
       states: {
         hover: {
-          borderColor: variables.colorPrimary,
-          color: variables.colorPrimary,
+          borderColor: variables.colorBlack,
+          color: variables.colorBase,
         },
       },
     },
 
     line: {
       enableMouseTracking: false,
-      color: variables.colorBase,
+      color: variables.colorGrayDarker,
       marker: {
         states: {
           hover: {
@@ -71,13 +72,13 @@ export default {
     },
 
     area: {
-      color: variables.colorBase,
-      fillColor: chroma(variables.colorBase).alpha(0.3).css(),
+      color: variables.colorGrayDarker,
+      fillColor: chroma(variables.colorGrayDarker).alpha(0.18).css(),
       marker: {
         states: {
           hover: {
-            lineColor: variables.colorBase,
-            fillColor: variables.colorInfo,
+            lineColor: variables.colorGrayDarker,
+            fillColor: variables.colorGrayLighter,
           },
         },
       },
@@ -107,8 +108,8 @@ export default {
       x: -5,
       tickPosition: 'inside',
     },
-    gridLineColor: chroma(variables.colorBase).alpha(0.2).css(),
-    lineColor: variables.colorBase,
+    gridLineColor: variables.colorGray,
+    lineColor: variables.colorGrayDark,
     tickLength: 0,
     opposite: true,
   }],
@@ -118,9 +119,10 @@ export default {
       style: tickLabelStyle,
       y: -8,
     },
-    lineColor: variables.colorBase,
+    lineColor: variables.colorGrayDark,
+    tickColor: variables.colorGrayDark,
     crosshair: {
-      color: chroma.mix(variables.colorBase, variables.colorInfo, 0.3).css(),
+      color: chroma.mix(variables.colorBase, variables.colorGrayDarker, 0.7).css(),
     },
   }],
 };

--- a/src/components/range-selector/range-selector.jsx
+++ b/src/components/range-selector/range-selector.jsx
@@ -82,7 +82,7 @@ RangeSelector.propTypes = {
     type: PropTypes.string,
     text: PropTypes.string,
   })),
-  variant: PropTypes.oneOf(['light', 'dark']),
+  variant: PropTypes.oneOf(['light', 'dark', 'muted']),
   clickHandler: PropTypes.func,
   selected: PropTypes.string,
 };

--- a/src/components/range-selector/range-selector.scss
+++ b/src/components/range-selector/range-selector.scss
@@ -19,6 +19,10 @@
     }
   }
 
+  &--muted {
+    background: $color-gray-light;
+  }
+
   &__btn {
     display: inline-block;
     appearance: none;


### PR DESCRIPTION
This adds a new theme to Graph and RangeSelector that looks like this:
![image](https://cloud.githubusercontent.com/assets/3505504/19158600/a3c93582-8be9-11e6-98c1-6e51b3ebcfb7.png)

Isn't that neat? :)