### PR TITLE
hovering a button shows pointing finger cursor instead of arrow

### DIFF
--- a/src/components/button/button.scss
+++ b/src/components/button/button.scss
@@ -65,6 +65,9 @@ $sizePaddings: (
     &:disabled {
       cursor: not-allowed;
     }
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &--block {


### PR DESCRIPTION
There was feedback from the team that when you hovered a button the cursor did not change to a pointing hand as expected. Added this feature.