### PR TITLE
bump react-svg-sprite-icon and fix peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
   "homepage": "https://nordnet.github.io/nordnet-ui-kit",
   "license": "MIT",
   "peerDependencies": {
-    "react": "^15.0.0",
-    "react-dom": "^15.0.0"
+    "react": "15.x",
+    "react-dom": "15.x"
   },
   "dependencies": {
     "array-equal": "^1.0.0",
@@ -68,7 +68,7 @@
     "react-prop-types": "^0.3.0",
     "react-pure-render": "^1.0.2",
     "react-select": "^1.0.0-rc.1",
-    "react-svg-sprite-icon": "^0.0.11"
+    "react-svg-sprite-icon": "^0.0.12"
   },
   "devDependencies": {
     "autoprefixer": "^6.3.1",
@@ -76,7 +76,7 @@
     "babel-core": "^6.4.5",
     "babel-loader": "^6.2.3",
     "babel-plugin-transform-object-rest-spread": "^6.6.5",
-    "babel-polyfill": "^6.16.0",
+    "babel-polyfill": "6.16.0",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-react": "^6.3.13",
     "babel-preset-react-hmre": "^1.1.1",


### PR DESCRIPTION
- Bumped react-svg-sprite-icon to fix problems with icons in IE11
- Fixed react peerDeps to be 15.x
- Forced babel-polyfill to 6.16.0 to fix IE problems in dev-mode