### PR TITLE
Feature/quickfix components without svg dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Badge, LabeledValue
 ### Quickfix ported components
 These components have removed the SCSS styling, but has not added it as JSS.
 
-Table, Tbody, Thead, Tfoot, Tr, Th, Td
+Table, Tbody, Thead, Tfoot, Tr, Th, Td,
+Button, GraphTooltip, HorizontalNav, Legend, Pane,
 
 ## 0.1.1
 * Updated to Webpack 2

--- a/src/components/alert/index.js
+++ b/src/components/alert/index.js
@@ -1,0 +1,1 @@
+export { default } from './alert';

--- a/src/components/badge/index.js
+++ b/src/components/badge/index.js
@@ -1,0 +1,1 @@
+export { default } from './badge';

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
-import './button.scss';
+// TODO: Move SCSS into JSS
+// import './button.scss';
 
 function Button({
   variant,

--- a/src/components/button/index.js
+++ b/src/components/button/index.js
@@ -1,0 +1,1 @@
+export { default } from './button';

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -1,0 +1,1 @@
+export { default } from './dropdown';

--- a/src/components/graph-tooltip/graph-tooltip.jsx
+++ b/src/components/graph-tooltip/graph-tooltip.jsx
@@ -2,7 +2,8 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import CompareTooltip from './compare-tooltip';
 import InstrumentTooltip from './instrument-tooltip';
-import './graph-tooltip.scss';
+// TODO: Move SCSS into JSS
+// import './graph-tooltip.scss';
 
 function renderContent(type, rest) {
   switch (type) {

--- a/src/components/horizontal-nav/horizontal-nav.jsx
+++ b/src/components/horizontal-nav/horizontal-nav.jsx
@@ -2,7 +2,8 @@ import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { kebabCase } from 'lodash';
 import c from 'color';
-import './horizontal-nav.scss';
+// TODO: Move SCSS into JSS
+// import './horizontal-nav.scss';
 
 function navItem(item) {
   const { label, url, key, active, ...rest } = item;

--- a/src/components/horizontal-nav/index.js
+++ b/src/components/horizontal-nav/index.js
@@ -1,1 +1,1 @@
-export { default } from './horizontal-nav.jsx';
+export { default } from './horizontal-nav';

--- a/src/components/input/index.js
+++ b/src/components/input/index.js
@@ -1,0 +1,1 @@
+export { default } from './input';

--- a/src/components/legend/index.js
+++ b/src/components/legend/index.js
@@ -1,1 +1,1 @@
-export { default } from './legend.jsx';
+export { default } from './legend';

--- a/src/components/legend/legend.jsx
+++ b/src/components/legend/legend.jsx
@@ -1,7 +1,8 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { kebabCase } from 'lodash';
-import './legend.scss';
+// TODO: Move SCSS into JSS
+// import './legend.scss';
 
 function legendItem({ color, label, value, ...rest }) {
   return (

--- a/src/components/nav-bar/index.js
+++ b/src/components/nav-bar/index.js
@@ -1,1 +1,1 @@
-export { default } from './nav-bar.jsx';
+export { default } from './nav-bar';

--- a/src/components/pane/index.js
+++ b/src/components/pane/index.js
@@ -1,0 +1,1 @@
+export { default } from './pane';

--- a/src/components/pane/pane.jsx
+++ b/src/components/pane/pane.jsx
@@ -2,7 +2,8 @@
 import React, { PropTypes } from 'react';
 import classNames from 'classnames';
 import { kebabCase } from 'lodash';
-import './pane.scss';
+// TODO: Move SCSS into JSS
+// import './pane.scss';
 
 class Pane extends React.PureComponent {
   constructor(props) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,16 @@
 // import Alert from './components/alert/alert';
 import Badge from './components/badge/badge';
-// import Button from './components/button/button';
+import Button from './components/button/button';
 // import Dropdown from './components/dropdown/dropdown';
 // import Flag from './components/flag/flag';
-// import GraphTooltip from './components/graph-tooltip';
-// import HorizontalNav from './components/horizontal-nav';
+import GraphTooltip from './components/graph-tooltip';
+import HorizontalNav from './components/horizontal-nav';
 // import Icon from './components/icon/icon';
 // import Input from './components/input/input';
 import LabeledValue from './components/labeled-value/labeled-value';
-// import Legend from './components/legend';
+import Legend from './components/legend';
 // import Logo from './components/logo/logo';
-// import Pane from './components/pane/pane';
+import Pane from './components/pane/pane';
 // import RadioGroup from './components/radio-group';
 // import RangeSelector from './components/range-selector/';
 // import RatioBar from './components/ratio-bar';
@@ -43,17 +43,17 @@ import {
 export {
   // Alert,
   Badge,
-  // Button,
+  Button,
   // Dropdown,
   // Flag,
-  // GraphTooltip,
-  // HorizontalNav,
+  GraphTooltip,
+  HorizontalNav,
   // Icon,
   // Input,
   LabeledValue,
-  // Legend,
+  Legend,
   // Logo,
-  // Pane,
+  Pane,
   // RadioGroup,
   // RangeSelector,
   // RatioBar,

--- a/styleguide.config.js
+++ b/styleguide.config.js
@@ -6,7 +6,12 @@ const config = require('./webpack.config')('styleguidist');
 
 const dir = path.join(__dirname, 'src');
 
-const portedComponents = ['badge', 'labeled-value', 'table', 'tbody', 'thead', 'tfoot', 'tr', 'th', 'td'];
+const portedComponents = [
+  'badge', 'labeled-value',
+  // Quickfix added
+  'table', 'tbody', 'thead', 'tfoot', 'tr', 'th', 'td',
+  'button', 'graph-tooltip', 'horizontal-nav', 'legend', 'pane',
+];
 
 function capitalize(string) {
   return string.charAt(0).toUpperCase() + string.slice(1);


### PR DESCRIPTION
Quickfix for components without svg dependencies (awaiting Icon fix for that one).

* Button
* GraphTooltip
* HorizontalNav
* Legend
* Pane

Also here I added `TODO: Move SCSS into JSS` so we remember to properly move the SCSS styling.
