### PR TITLE
Re-work how icons get presented in the documentatation

### DIFF
--- a/src/components/icon/icon.md
+++ b/src/components/icon/icon.md
@@ -18,23 +18,38 @@ All available icons:
 
     const { Icon } = require('../../'); // nordnet-ui-kit
 
-    const style = {
-      display: 'inline-block',
-      textAlign: 'center',
-      padding: 16,
-      minWidth: '20%',
+    const containerStyle = {
+      columns: 'auto 200px',
     };
+
+    const style = {
+      display: 'flex',
+      alignItems: 'center',
+    };
+
+    const iconStyle = {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: 40,
+      height: 16,
+    };
+
     const icons = Object.keys(Icon);
 
-    <div>
+    <div style={containerStyle}>
       {icons
         .map(iconName => {
           const IconComponent = Icon[iconName];
 
           return (
-            <div key={ iconName } style={ style }>
-              <IconComponent stroke="#00A9EC" fill="#00A9EC" />
-              <div style={{ fontSize: 12, fontFamily: '"Hack", monospace' }}>{ iconName }</div>
+            <div style={{display: 'inline-block', width: '100%', padding: 4, height: 20,}}>
+              <div key={ iconName } style={ style }>
+                <div style={iconStyle}>
+                  <IconComponent stroke="#00A9EC" fill="#00A9EC" />
+                </div>
+                <div style={{ fontSize: 12, fontFamily: '"Hack", monospace' }}>{ iconName }</div>
+              </div>
             </div>
           );
         }


### PR DESCRIPTION
To make it easier to find a specific icon the layout was changed:

From this: 
![image](https://cloud.githubusercontent.com/assets/3505504/25660630/6fa06cee-300d-11e7-958a-1a9eeb19c58d.png)

To this: 
![image](https://cloud.githubusercontent.com/assets/3505504/25660643/79cd3fee-300d-11e7-9ed9-508adf1437c1.png)

