### PR TITLE
Feature/allow tabbing on segmented control

### DIFF
--- a/src/components/segmented-control/segmented-control-styles.jsx
+++ b/src/components/segmented-control/segmented-control-styles.jsx
@@ -10,7 +10,8 @@ export default createStyleSheet('SegmentedControl', (theme) => {
       display: 'inline-flex',
 
       '& input': {
-        display: 'none',
+        opacity: 0,
+        position: 'absolute',
       },
     },
 

--- a/src/components/segmented-control/segmented-control-styles.jsx
+++ b/src/components/segmented-control/segmented-control-styles.jsx
@@ -53,9 +53,7 @@ export default createStyleSheet('SegmentedControl', (theme) => {
     },
 
     focus: {
-      borderStyle: 'dotted',
-      borderRight: `2px dotted ${palette.color.grayLight} !important`,
-      borderLeftStyle: 'dotted !important',
+      boxShadow: `inset 0 0 1px 1px ${palette.variant.primary}`,
     },
 
     buttonLeft: {

--- a/src/components/segmented-control/segmented-control-styles.jsx
+++ b/src/components/segmented-control/segmented-control-styles.jsx
@@ -12,6 +12,17 @@ export default createStyleSheet('SegmentedControl', (theme) => {
       '& input': {
         opacity: 0,
         position: 'absolute',
+        left: 0,
+        width: '100%',
+        height: '100%',
+        margin: 0,
+      },
+    },
+
+    radio: {
+      '& label': {
+        paddingTop: '8px',
+        display: 'block',
       },
     },
 
@@ -23,11 +34,8 @@ export default createStyleSheet('SegmentedControl', (theme) => {
       fontSize: '12px',
       fontFamily: typography.primary.fontFamily,
       color: palette.text.default,
-      paddingTop: '8px',
-      paddingBottom: '8px',
-      paddingLeft: '10px',
-      paddingRight: '10px',
       backgroundColor: 'inherit',
+      position: 'relative',
 
       '& + &': {
         borderLeft: `1px solid ${palette.color.grayLight}`,
@@ -35,11 +43,19 @@ export default createStyleSheet('SegmentedControl', (theme) => {
 
       '& label': {
         cursor: 'pointer',
+        margin: '0 12px',
+        lineHeight: '28px',
       },
     },
 
     selected: {
       backgroundColor: palette.color.grayLighter,
+    },
+
+    focus: {
+      borderStyle: 'dotted',
+      borderRight: `2px dotted ${palette.color.grayLight} !important`,
+      borderLeftStyle: 'dotted !important',
     },
 
     buttonLeft: {

--- a/src/components/segmented-control/segmented-control.jsx
+++ b/src/components/segmented-control/segmented-control.jsx
@@ -26,6 +26,7 @@ class SegmentedControl extends React.PureComponent {
     }
     this.renderChild = this.renderChild.bind(this);
     this.handleChange = this.handleChange.bind(this);
+    this.handleFocus = this.handleFocus.bind(this);
     this.childSelectedState = this.childSelectedState.bind(this);
     this.classes = this.context.styleManager.render(SegmentedControlStyles);
   }
@@ -52,6 +53,13 @@ class SegmentedControl extends React.PureComponent {
       };
     }
     return null;
+  }
+
+  handleFocus(e, index) {
+    const focus = e.type === 'focus' ? index : '';
+    this.setState({
+      focus,
+    });
   }
 
   handleChange(e) {
@@ -84,6 +92,9 @@ class SegmentedControl extends React.PureComponent {
       [this.classes.selected]: selected,
       [this.classes.buttonLeft]: index === 0,
       [this.classes.buttonRight]: this.props.children.map ? index === this.props.children.length - 1 : true,
+      [this.classes.focus]: index === this.state.focus,
+      [this.classes.radio]: this.props.type === 'radio',
+      [this.classes.checkbox]: this.props.type === 'checkbox',
     });
     const inputId = `sc-${this.props.name}-${index}`;
     return (<span className={usedClassName} key={`sc-${this.props.name}-${childValue}`}>
@@ -94,6 +105,8 @@ class SegmentedControl extends React.PureComponent {
         value={childValue || index}
         checked={selected}
         onChange={this.handleChange}
+        onFocus={event => this.handleFocus(event, index)}
+        onBlur={event => this.handleFocus(event, index)}
       />
       <label htmlFor={inputId}>{ child }</label>
     </span>);

--- a/src/components/segmented-control/segmented-control.md
+++ b/src/components/segmented-control/segmented-control.md
@@ -4,7 +4,6 @@ Radio type (using icons):
     const color = require('../../styles/color').default;
 
     <SegmentedControl
-      onChange={ console.log }
       value="green"
       name="colorRadio"
       type="radio"
@@ -23,7 +22,6 @@ Radio type (using icons):
 Checkbox type:
 
     <SegmentedControl
-      onChange={ console.log }
       name="colorCheck" type="checkbox">
       <span value="red" checked={true}>Red</span>
       <span value="green">Green</span>
@@ -34,7 +32,6 @@ Checkbox type:
 With single option, "checkbox" type:
 
     <SegmentedControl
-      onChange={ console.log }
       name="colors"
       type="checkbox">
       <span value="red" checked={true}>Red</span>


### PR DESCRIPTION
Easiest way to test is by running it locally. The keyboard control on SegmentedControl should be like native browser radio/checkbox, e.g.:

- navigate/check a set of radio buttons with both up/down and left/right
- navigate checkboxes with tab
- check checkbox with space