### PR TITLE
Avoid id collision with the flags

### DIFF
--- a/src/components/flag/flags/cn.jsx
+++ b/src/components/flag/flags/cn.jsx
@@ -6,44 +6,14 @@ export default function FlagCn({
   return (
     <svg aria-hidden="true" focusable="false" {...rest}>
       <defs>
-        <path id="a" fill="#ffde00" d="M-.588.81L0-1 .588.81-.952-.31H.952z" />
+        <path id="cn_a" fill="#ffde00" d="M-.588.81L0-1 .588.81-.952-.31H.952z" />
       </defs>
       <path d="M0 0h640v480H0z" fill="#de2910" />
-      <path
-        fill="#ffde00"
-        d="M-.588.81L0-1 .588.81-.952-.31H.952z"
-        transform="matrix(71.9991 0 0 72 119.999 120)"
-        width="30"
-        height="20"
-      />
-      <path
-        fill="#ffde00"
-        d="M-.588.81L0-1 .588.81-.952-.31H.952z"
-        transform="matrix(-12.33562 -20.5871 20.58684 -12.33577 240.291 47.996)"
-        width="30"
-        height="20"
-      />
-      <path
-        fill="#ffde00"
-        d="M-.588.81L0-1 .588.81-.952-.31H.952z"
-        transform="matrix(-3.38573 -23.75998 23.75968 -3.38578 287.95 95.796)"
-        width="30"
-        height="20"
-      />
-      <path
-        fill="#ffde00"
-        d="M-.588.81L0-1 .588.81-.952-.31H.952z"
-        transform="matrix(6.5991 -23.0749 23.0746 6.59919 287.959 168.012)"
-        width="30"
-        height="20"
-      />
-      <path
-        fill="#ffde00"
-        d="M-.588.81L0-1 .588.81-.952-.31H.952z"
-        transform="matrix(14.9991 -18.73557 18.73533 14.99929 239.933 216.054)"
-        width="30"
-        height="20"
-      />
+      <use xlinkHref="#cn_a" transform="matrix(71.9991 0 0 72 119.999 120)" width="30" height="20" />
+      <use xlinkHref="#cn_a" transform="matrix(-12.33562 -20.5871 20.58684 -12.33577 240.291 47.996)" width="30" height="20" />
+      <use xlinkHref="#cn_a" transform="matrix(-3.38573 -23.75998 23.75968 -3.38578 287.95 95.796)" width="30" height="20" />
+      <use xlinkHref="#cn_a" transform="matrix(6.5991 -23.0749 23.0746 6.59919 287.959 168.012)" width="30" height="20" />
+      <use xlinkHref="#cn_a" transform="matrix(14.9991 -18.73557 18.73533 14.99929 239.933 216.054)" width="30" height="20" />
     </svg>
   );
 }

--- a/src/components/flag/flags/eu.jsx
+++ b/src/components/flag/flags/eu.jsx
@@ -6,30 +6,30 @@ export default function FlagEu({
   return (
     <svg {...rest}>
       <defs>
-        <g id="d">
-          <g id="b">
-            <path d="M0-1l-.31.95.477.156z" id="a" />
-            <use transform="scale(-1 1)" xlinkHref="#a" />
+        <g id="eu_d">
+          <g id="eu_b">
+            <path d="M0-1l-.31.95.477.156z" id="eu_a" />
+            <use transform="scale(-1 1)" xlinkHref="#eu_a" />
           </g>
-          <g id="c">
-            <use transform="rotate(72)" xlinkHref="#b" />
-            <use transform="rotate(144)" xlinkHref="#b" />
+          <g id="eu_c">
+            <use transform="rotate(72)" xlinkHref="#eu_b" />
+            <use transform="rotate(144)" xlinkHref="#eu_b" />
           </g>
-          <use transform="scale(-1 1)" xlinkHref="#c" />
+          <use transform="scale(-1 1)" xlinkHref="#eu_c" />
         </g>
       </defs>
       <path fill="#039" d="M0 0h640v480H0z" />
       <g transform="translate(320 242.263) scale(23.7037)" fill="#fc0">
-        <use height="100%" width="100%" xlinkHref="#d" y="-6" />
-        <use height="100%" width="100%" xlinkHref="#d" y="6" />
-        <g id="e">
-          <use height="100%" width="100%" xlinkHref="#d" x="-6" />
-          <use height="100%" width="100%" xlinkHref="#d" transform="rotate(-144 -2.344 -2.11)" />
-          <use height="100%" width="100%" xlinkHref="#d" transform="rotate(144 -2.11 -2.344)" />
-          <use height="100%" width="100%" xlinkHref="#d" transform="rotate(72 -4.663 -2.076)" />
-          <use height="100%" width="100%" xlinkHref="#d" transform="rotate(72 -5.076 .534)" />
+        <use height="100%" width="100%" xlinkHref="#eu_d" y="-6" />
+        <use height="100%" width="100%" xlinkHref="#eu_d" y="6" />
+        <g id="eu_e">
+          <use height="100%" width="100%" xlinkHref="#eu_d" x="-6" />
+          <use height="100%" width="100%" xlinkHref="#eu_d" transform="rotate(-144 -2.344 -2.11)" />
+          <use height="100%" width="100%" xlinkHref="#eu_d" transform="rotate(144 -2.11 -2.344)" />
+          <use height="100%" width="100%" xlinkHref="#eu_d" transform="rotate(72 -4.663 -2.076)" />
+          <use height="100%" width="100%" xlinkHref="#eu_d" transform="rotate(72 -5.076 .534)" />
         </g>
-        <use height="100%" width="100%" xlinkHref="#e" transform="scale(-1 1)" />
+        <use height="100%" width="100%" xlinkHref="#eu_e" transform="scale(-1 1)" />
       </g>
     </svg>
   );

--- a/src/components/flag/flags/gb.jsx
+++ b/src/components/flag/flags/gb.jsx
@@ -6,11 +6,11 @@ export default function FlagGb({
   return (
     <svg aria-hidden="true" focusable="false" {...rest}>
       <defs>
-        <clipPath id="a">
+        <clipPath id="gb_a">
           <path fillOpacity=".67" d="M-85.333 0h682.67v512h-682.67z" />
         </clipPath>
       </defs>
-      <g clipPath="url(#a)" transform="translate(80) scale(.94)">
+      <g clipPath="url(#gb_a)" transform="translate(80) scale(.94)">
         <g strokeWidth="1pt">
           <path fill="#006" d="M-256 0H768.02v512.01H-256z" />
           <path

--- a/src/components/flag/flags/jp.jsx
+++ b/src/components/flag/flags/jp.jsx
@@ -6,11 +6,11 @@ export default function FlagJp({
   return (
     <svg aria-hidden="true" focusable="false" {...rest}>
       <defs>
-        <clipPath id="a">
+        <clipPath id="jp_a">
           <path fillOpacity=".67" d="M-88.001 32h640v480h-640z" />
         </clipPath>
       </defs>
-      <g fillRule="evenodd" clipPath="url(#a)" transform="translate(88.001 -32)" strokeWidth="1pt">
+      <g fillRule="evenodd" clipPath="url(#jp_a)" transform="translate(88.001 -32)" strokeWidth="1pt">
         <path fill="#fff" d="M-128 32h720v480h-720z" />
         <ellipse rx="194.93" ry="194.93" transform="translate(-168.44 8.618) scale(.76554)" cy="344.05" cx="523.08" fill="#d30000" />
       </g>


### PR DESCRIPTION
Prepending the ids used in the flags with the name of the flag.
Fixes #207.

![screen shot 2017-05-11 at 13 33 55](https://cloud.githubusercontent.com/assets/1844083/25947164/930b9ec8-364e-11e7-8a9b-427abf0ac00c.png)
