### PR TITLE
Make default buttons gray. New modifier="action" to make them blue.

### DIFF
--- a/src/components/button/button-styles.jsx
+++ b/src/components/button/button-styles.jsx
@@ -96,13 +96,13 @@ export default createStyleSheet('Button', (theme) => {
     },
 
     primary: {
-      background: palette.variant.primary,
-      border: `2px solid ${palette.variant.primary}`,
+      background: palette.background.secondary,
+      border: `2px solid ${palette.background.secondary}`,
       color: palette.shades.dark.text.default,
 
       '&:hover': {
-        background: focusColor(palette.variant.primary),
-        borderColor: focusColor(palette.variant.primary),
+        background: focusColor(palette.background.secondary),
+        borderColor: focusColor(palette.background.secondary),
       },
 
       '&:disabled': {
@@ -116,6 +116,7 @@ export default createStyleSheet('Button', (theme) => {
         },
       },
 
+      '&.action': buttonModifierFn('primary', palette.variant.primary, focusColor(palette.variant.primary)),
       '&.success': buttonModifierFn('primary', palette.variant.success, focusColor(palette.variant.success)),
       '&.warning': {
         ...buttonModifierFn('primary', palette.variant.warning, focusColor(palette.variant.warning)),
@@ -126,12 +127,12 @@ export default createStyleSheet('Button', (theme) => {
 
     secondary: {
       background: 'none',
-      color: palette.variant.primary,
-      border: `2px solid ${palette.variant.primary}`,
+      color: palette.background.secondary,
+      border: `2px solid ${palette.background.secondary}`,
 
       '&:hover': {
-        color: c(palette.variant.primary).darken(0.1).hex(),
-        borderColor: c(palette.variant.primary).darken(0.1).hex(),
+        color: c(palette.background.secondary).darken(0.1).hex(),
+        borderColor: c(palette.background.secondary).darken(0.1).hex(),
       },
 
       '&:disabled': {
@@ -144,6 +145,7 @@ export default createStyleSheet('Button', (theme) => {
         },
       },
 
+      '&.action': buttonModifierFn('secondary', palette.variant.primary, focusColor(palette.variant.primary)),
       '&.success': buttonModifierFn('secondary', palette.variant.success, focusColor(palette.variant.success)),
       '&.warning': buttonModifierFn('secondary', palette.variant.warning, focusColor(palette.variant.warning)),
       '&.danger': buttonModifierFn('secondary', palette.variant.danger, focusColor(palette.variant.danger)),
@@ -153,13 +155,13 @@ export default createStyleSheet('Button', (theme) => {
       background: 'none',
       paddingLeft: 0,
       paddingRight: 0,
-      color: palette.variant.primary,
+      color: palette.background.secondary,
       border: '2px solid transparent',
       fontWeight: 600,
       cursor: 'pointer',
 
       '&:hover': {
-        color: c(palette.variant.primary).darken(0.2).hex(), // was $color-primary-dark
+        color: c(palette.background.secondary).darken(0.2).hex(), // was $color-primary-dark
       },
 
       '&:disabled': {
@@ -170,6 +172,7 @@ export default createStyleSheet('Button', (theme) => {
         },
       },
 
+      '&.action': buttonModifierFn('link', palette.variant.primary, focusColor(palette.variant.primary)),
       '&.success': buttonModifierFn('link', palette.variant.success, focusColor(palette.variant.success)),
       '&.warning': buttonModifierFn('link', palette.variant.warning, focusColor(palette.variant.warning)),
       '&.danger': buttonModifierFn('link', palette.variant.danger, focusColor(palette.variant.danger)),

--- a/src/components/button/button-styles.jsx
+++ b/src/components/button/button-styles.jsx
@@ -3,8 +3,9 @@ import c from 'color';
 
 // This function was created because 'focused' versions on colors were not found in the palette
 const focusColor = color => (c(color).darken(0.1).hex());
+const disableColor = color => (c(color).lighten(0.7).hex());
 
-const buttonModifierFn = (variant, color, colorFocus) => {
+const buttonModifierFn = (variant, color, colorFocus, colorDisabled) => {
   const variantDict = {
     primary: {
       background: color,
@@ -13,6 +14,12 @@ const buttonModifierFn = (variant, color, colorFocus) => {
       '&:hover': {
         background: colorFocus,
         borderColor: colorFocus,
+      },
+
+      '&:disabled': {
+        background: colorDisabled,
+        borderColor: colorDisabled,
+        color: '#fff',
       },
     },
 
@@ -23,6 +30,11 @@ const buttonModifierFn = (variant, color, colorFocus) => {
       '&:hover': {
         color: colorFocus,
         borderColor: colorFocus,
+      },
+
+      '&:disabled': {
+        color: colorDisabled,
+        borderColor: colorDisabled,
       },
     },
 
@@ -116,13 +128,33 @@ export default createStyleSheet('Button', (theme) => {
         },
       },
 
-      '&.action': buttonModifierFn('primary', palette.variant.primary, focusColor(palette.variant.primary)),
-      '&.success': buttonModifierFn('primary', palette.variant.success, focusColor(palette.variant.success)),
+      '&.action': buttonModifierFn(
+        'primary',
+        palette.variant.primary,
+        focusColor(palette.variant.primary),
+        disableColor(palette.variant.primary),
+      ),
+      '&.success': buttonModifierFn(
+        'primary',
+        palette.variant.success,
+        focusColor(palette.variant.success),
+        disableColor(palette.variant.success),
+      ),
       '&.warning': {
-        ...buttonModifierFn('primary', palette.variant.warning, focusColor(palette.variant.warning)),
-        color: palette.text.default,
+        ...buttonModifierFn(
+          'primary',
+          palette.variant.warning,
+          focusColor(palette.variant.warning),
+          c(palette.variant.warning).lighten(0.3).hex(),
+        ),
+        color: `${palette.text.default}!important`,
       },
-      '&.danger': buttonModifierFn('primary', palette.variant.danger, focusColor(palette.variant.danger)),
+      '&.danger': buttonModifierFn(
+        'primary',
+        palette.variant.danger,
+        focusColor(palette.variant.danger),
+        disableColor(palette.variant.danger),
+      ),
     },
 
     secondary: {
@@ -145,10 +177,33 @@ export default createStyleSheet('Button', (theme) => {
         },
       },
 
-      '&.action': buttonModifierFn('secondary', palette.variant.primary, focusColor(palette.variant.primary)),
-      '&.success': buttonModifierFn('secondary', palette.variant.success, focusColor(palette.variant.success)),
-      '&.warning': buttonModifierFn('secondary', palette.variant.warning, focusColor(palette.variant.warning)),
-      '&.danger': buttonModifierFn('secondary', palette.variant.danger, focusColor(palette.variant.danger)),
+      '&.action': buttonModifierFn(
+        'secondary',
+        palette.variant.primary,
+        focusColor(palette.variant.primary),
+        disableColor(palette.variant.primary),
+      ),
+      '&.success': buttonModifierFn(
+        'secondary',
+        palette.variant.success,
+        focusColor(palette.variant.success),
+        disableColor(palette.variant.success),
+      ),
+      '&.warning': {
+        ...buttonModifierFn(
+          'secondary',
+          palette.variant.warning,
+          focusColor(palette.variant.warning),
+          c(palette.variant.warning).lighten(0.3).hex(),
+        ),
+        color: `${palette.text.default}!important`,
+      },
+      '&.danger': buttonModifierFn(
+        'secondary',
+        palette.variant.danger,
+        focusColor(palette.variant.danger),
+        disableColor(palette.variant.danger),
+      ),
     },
 
     link: {

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -18,6 +18,7 @@ function Button({
   const isPrimary = variant === 'primary';
   const isSecondary = variant === 'secondary';
   const isLink = variant === 'link';
+  const isAction = modifier === 'action';
   const isSuccess = modifier === 'success';
   const isWarning = modifier === 'warning';
   const isDanger = modifier === 'danger';
@@ -27,6 +28,7 @@ function Button({
     [classes.primary]: isPrimary,
     [classes.secondary]: isSecondary,
     [classes.link]: isLink,
+    action: isAction,
     success: isSuccess,
     warning: isWarning,
     danger: isDanger,

--- a/src/components/button/button.md
+++ b/src/components/button/button.md
@@ -6,6 +6,7 @@ Primary button:
 
     <div>
       <Button variant="primary" style= { style }>Click Me</Button>
+      <Button variant="primary" modifier="action" style= { style }>Click Me</Button>
       <Button variant="primary" modifier="danger" style= { style }>Click Me</Button>
       <Button variant="primary" modifier="warning" style= { style }>Click Me</Button>
       <Button variant="primary" modifier="success" style= { style }>Click Me</Button>
@@ -19,6 +20,7 @@ Secondary button:
 
     <div>
       <Button variant="secondary" style={ style }>Click Me</Button>
+      <Button variant="secondary" modifier="action" style={ style }>Click Me</Button>
       <Button variant="secondary" modifier="danger" style={ style }>Click Me</Button>
       <Button variant="secondary" modifier="warning" style={ style }>Click Me</Button>
       <Button variant="secondary" modifier="success" style={ style }>Click Me</Button>
@@ -32,6 +34,7 @@ Link button:
 
     <div>
       <Button variant="link" style={ style }>Click Me</Button>
+      <Button variant="link" modifier="action" style={ style }>Click Me</Button>
       <Button variant="link" modifier="danger" style={ style }>Click Me</Button>
       <Button variant="link" modifier="warning" style={ style }>Click Me</Button>
       <Button variant="link" modifier="success" style={ style }>Click Me</Button>

--- a/src/components/button/button.md
+++ b/src/components/button/button.md
@@ -12,6 +12,20 @@ Primary button:
       <Button variant="primary" modifier="success" style= { style }>Click Me</Button>
     </div>
 
+Primary, disabled:
+
+    const style = {
+      marginRight: 16,
+    };
+
+    <div>
+      <Button variant="primary" disabled style= { style }>Disabled</Button>
+      <Button variant="primary" disabled modifier="action" style= { style }>Disabled</Button>
+      <Button variant="primary" disabled modifier="danger" style= { style }>Disabled</Button>
+      <Button variant="primary" disabled modifier="warning" style= { style }>Disabled</Button>
+      <Button variant="primary" disabled modifier="success" style= { style }>Disabled</Button>
+    </div>
+
 Secondary button:
 
     const style = {
@@ -24,6 +38,20 @@ Secondary button:
       <Button variant="secondary" modifier="danger" style={ style }>Click Me</Button>
       <Button variant="secondary" modifier="warning" style={ style }>Click Me</Button>
       <Button variant="secondary" modifier="success" style={ style }>Click Me</Button>
+    </div>
+
+Secondary, disabled:
+
+    const style = {
+      marginRight: 16,
+    };
+
+    <div>
+      <Button variant="secondary" disabled style={ style }>Click Me</Button>
+      <Button variant="secondary" disabled modifier="action" style={ style }>Click Me</Button>
+      <Button variant="secondary" disabled modifier="danger" style={ style }>Click Me</Button>
+      <Button variant="secondary" disabled modifier="warning" style={ style }>Click Me</Button>
+      <Button variant="secondary" disabled modifier="success" style={ style }>Click Me</Button>
     </div>
 
 Link button:


### PR DESCRIPTION
This fixes #212.

Also in the same PR I added better handling of the disabled states, which we previously did not have in the corresponding modifier colors.

From the design:
![screen shot 2017-05-12 at 11 03 38](https://cloud.githubusercontent.com/assets/1844083/25991186/bdd62e16-3702-11e7-82e4-530f4c794a59.png)

New implementation:
![screen shot 2017-05-12 at 11 03 49](https://cloud.githubusercontent.com/assets/1844083/25991197/c4e87bdc-3702-11e7-9764-c4a19b778703.png)
