### PR TITLE
Set pointer-events to none on icons

### DIFF
--- a/src/components/icon/icon.jsx
+++ b/src/components/icon/icon.jsx
@@ -31,4 +31,5 @@ Icon.defaultProps = {
   height: 16,
   width: 16,
   viewBox: '0 0 16 16',
+  style: { pointerEvents: 'none' },
 };

--- a/src/components/icon/icons/apartment.jsx
+++ b/src/components/icon/icons/apartment.jsx
@@ -6,10 +6,16 @@ export default function Apartment({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
+
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <rect strokeWidth={strokeWidth} x="2" y="1" width="12" height="14" />
@@ -32,6 +38,7 @@ Apartment.propTypes = {
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,
+  ...Icon.propTypes,
 };
 
 Apartment.defaultProps = Icon.defaultProps;

--- a/src/components/icon/icons/arrowDown.jsx
+++ b/src/components/icon/icons/arrowDown.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ArrowLeft from './arrowLeft';
+import Icon from '../icon';
 
 export default function ArrowDown({ style: styleProp, ...rest }) {
   const style = {
     transform: 'rotate(0.625turn)',
     ...styleProp,
+    ...Icon.defaultProps.style,
   };
   return <ArrowLeft style={style} {...rest} />;
 }

--- a/src/components/icon/icons/arrowLeft.jsx
+++ b/src/components/icon/icons/arrowLeft.jsx
@@ -6,10 +6,16 @@ export default function ArrowLeft({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
+
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g transform="translate(0, 2.7)" fillRule="nonzero" fill={fill}>
           <g>
@@ -34,6 +40,7 @@ ArrowLeft.propTypes = {
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,
+  ...Icon.propTypes,
 };
 
 ArrowLeft.defaultProps = {

--- a/src/components/icon/icons/arrowRight.jsx
+++ b/src/components/icon/icons/arrowRight.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ArrowLeft from './arrowLeft';
+import Icon from '../icon';
 
 export default function ArrowRight({ style: styleProp, ...rest }) {
   const style = {
     transform: 'rotate(0.5turn)',
     ...styleProp,
+    ...Icon.defaultProps.style,
   };
   return <ArrowLeft style={style} {...rest} />;
 }

--- a/src/components/icon/icons/arrowUp.jsx
+++ b/src/components/icon/icons/arrowUp.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ArrowLeft from './arrowLeft';
+import Icon from '../icon';
 
 export default function ArrowUp({ style: styleProp, ...rest }) {
   const style = {
     transform: 'rotate(0.375turn)',
     ...styleProp,
+    ...Icon.defaultProps.style,
   };
   return <ArrowLeft style={style} {...rest} />;
 }

--- a/src/components/icon/icons/arrowUpDown.jsx
+++ b/src/components/icon/icons/arrowUpDown.jsx
@@ -6,10 +6,16 @@ export default function ArrowUpDown({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
+
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g strokeWidth={strokeWidth} stroke={stroke}>
           <polyline points="13 15 8 15 8 10" />
@@ -23,6 +29,7 @@ export default function ArrowUpDown({
 }
 
 ArrowUpDown.propTypes = {
+  ...Icon.defaultProps,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/balloon.jsx
+++ b/src/components/icon/icons/balloon.jsx
@@ -6,10 +6,15 @@ export default function Balloon({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -37,6 +42,7 @@ export default function Balloon({
 }
 
 Balloon.propTypes = {
+  ...Icon.defaultProps,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/bell.jsx
+++ b/src/components/icon/icons/bell.jsx
@@ -6,10 +6,16 @@ export default function Bell({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
+
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M13,9 L14,10 L14,12 L2,12 L2,10 L3,9 L3,6 C3,3.2 5.2,1 8,1 L8,1 C10.8,1 13,3.2 13,6 L13,9 L13,9 Z" />
@@ -21,6 +27,7 @@ export default function Bell({
 }
 
 Bell.propTypes = {
+  ...Icon.PropTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/calendar.jsx
+++ b/src/components/icon/icons/calendar.jsx
@@ -6,10 +6,15 @@ export default function Calendar({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <rect strokeWidth={strokeWidth} x="2" y="4" width="13" height="10" />
@@ -27,6 +32,7 @@ export default function Calendar({
 }
 
 Calendar.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/cart.jsx
+++ b/src/components/icon/icons/cart.jsx
@@ -6,10 +6,15 @@ export default function Chart({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -43,6 +48,7 @@ export default function Chart({
 }
 
 Chart.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/checkmark.jsx
+++ b/src/components/icon/icons/checkmark.jsx
@@ -6,10 +6,15 @@ export default function Checkmark({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M0.700012207,3.44100952 L3.69873047,6.43997192 L9.29998779,0.839996338" />
@@ -20,6 +25,7 @@ export default function Checkmark({
 }
 
 Checkmark.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/checkmarkLarge.jsx
+++ b/src/components/icon/icons/checkmarkLarge.jsx
@@ -6,10 +6,15 @@ export default function CheckmarkLarge({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M14.4000244,3 L5.40002441,12 L1.40002441,8" />
@@ -20,6 +25,7 @@ export default function CheckmarkLarge({
 }
 
 CheckmarkLarge.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/chevronDown.jsx
+++ b/src/components/icon/icons/chevronDown.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import ChevronUp from './chevronUp';
+import Icon from '../icon';
 
 export default function ChevronDown({ style: styleProp, ...rest }) {
   const style = {
     transform: 'rotate(0.5turn)',
     ...styleProp,
+    ...Icon.defaultProps.style,
   };
 
   return <ChevronUp style={style} {...rest} />;

--- a/src/components/icon/icons/chevronUp.jsx
+++ b/src/components/icon/icons/chevronUp.jsx
@@ -6,10 +6,15 @@ export default function ChevronUp({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -25,6 +30,7 @@ export default function ChevronUp({
 }
 
 ChevronUp.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/circleArrow.jsx
+++ b/src/components/icon/icons/circleArrow.jsx
@@ -6,10 +6,15 @@ export default function CircleArrow({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -33,6 +38,7 @@ export default function CircleArrow({
 }
 
 CircleArrow.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/circleSlash.jsx
+++ b/src/components/icon/icons/circleSlash.jsx
@@ -6,10 +6,15 @@ export default function CircleSlash({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <circle cx="8" cy="8" r="7" />
@@ -21,6 +26,7 @@ export default function CircleSlash({
 }
 
 CircleSlash.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/clock.jsx
+++ b/src/components/icon/icons/clock.jsx
@@ -6,10 +6,15 @@ export default function Clock({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -44,6 +49,7 @@ export default function Clock({
 }
 
 Clock.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/close.jsx
+++ b/src/components/icon/icons/close.jsx
@@ -6,10 +6,15 @@ export default function Close({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M1.875,1.875 L14.125,14.125" />
@@ -21,6 +26,7 @@ export default function Close({
 }
 
 Close.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/cloud.jsx
+++ b/src/components/icon/icons/cloud.jsx
@@ -6,10 +6,15 @@ export default function Cloud({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path
@@ -24,6 +29,7 @@ export default function Cloud({
 }
 
 Cloud.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/edit.jsx
+++ b/src/components/icon/icons/edit.jsx
@@ -6,10 +6,15 @@ export default function Edit({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -43,6 +48,7 @@ export default function Edit({
 }
 
 Edit.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/ellipsis.jsx
+++ b/src/components/icon/icons/ellipsis.jsx
@@ -6,10 +6,15 @@ export default function Ellipsis({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g
           transform="translate(8.000000, 8.000000) translate(-2.000000, -8.000000) translate(-5.000000, 7.000000)"
@@ -29,6 +34,7 @@ export default function Ellipsis({
 }
 
 Ellipsis.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/exclamationPoint.jsx
+++ b/src/components/icon/icons/exclamationPoint.jsx
@@ -6,10 +6,15 @@ export default function ExcalmationPoint({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g transform="translate(-1.000000, 0.000000)" stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M2,0 L2,5" />
@@ -21,6 +26,7 @@ export default function ExcalmationPoint({
 }
 
 ExcalmationPoint.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/expand.jsx
+++ b/src/components/icon/icons/expand.jsx
@@ -6,10 +6,15 @@ export default function Expand({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -43,6 +48,7 @@ export default function Expand({
 }
 
 Expand.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/film.jsx
+++ b/src/components/icon/icons/film.jsx
@@ -6,10 +6,15 @@ export default function Film({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <rect strokeWidth={strokeWidth} x="1" y="2" width="14" height="13" />
@@ -28,6 +33,7 @@ export default function Film({
 }
 
 Film.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/filter.jsx
+++ b/src/components/icon/icons/filter.jsx
@@ -6,10 +6,15 @@ export default function Filter({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -40,6 +45,7 @@ export default function Filter({
 }
 
 Filter.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/floppyDisk.jsx
+++ b/src/components/icon/icons/floppyDisk.jsx
@@ -6,10 +6,15 @@ export default function FloppyDisk({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M15,15 L1,15 L1,1 L13.5,1 L15,2.5 L15,15 Z" />
@@ -23,6 +28,7 @@ export default function FloppyDisk({
 }
 
 FloppyDisk.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/folder.jsx
+++ b/src/components/icon/icons/folder.jsx
@@ -6,10 +6,15 @@ export default function Folder({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g strokeWidth={strokeWidth} stroke={stroke}>
           <path d="M15,4 L15,14 L1,14 L1,2 L6,2 L8,4 L15,4 Z" />
@@ -20,6 +25,7 @@ export default function Folder({
 }
 
 Folder.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/graphArea.jsx
+++ b/src/components/icon/icons/graphArea.jsx
@@ -6,10 +6,15 @@ export default function GraphArea({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <polyline stroke={stroke} strokeWidth={strokeWidth} points="1 0 1 15 16 15" />
         <polygon fill={fill} points="3 13 3 9 6 6 9 9 16 2 16 13" />
@@ -19,6 +24,7 @@ export default function GraphArea({
 }
 
 GraphArea.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/graphCandlestick.jsx
+++ b/src/components/icon/icons/graphCandlestick.jsx
@@ -6,10 +6,15 @@ export default function GraphCandlestick({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <rect x="1.5" y="0.5" width="1" height="4" />
@@ -28,6 +33,7 @@ export default function GraphCandlestick({
 }
 
 GraphCandlestick.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/graphLine.jsx
+++ b/src/components/icon/icons/graphLine.jsx
@@ -6,10 +6,15 @@ export default function GraphLine({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <polyline points="0 9.6 5.6 4 8.8 7.2 16 0" />
@@ -20,6 +25,7 @@ export default function GraphLine({
 }
 
 GraphLine.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/graphVolume.jsx
+++ b/src/components/icon/icons/graphVolume.jsx
@@ -6,10 +6,15 @@ export default function GraphVolume({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g transform="translate(-1.0, 0)" stroke={stroke}>
           <rect x="11.5" y="6.5" width="3" height="9" rx="0.7" />
@@ -22,6 +27,7 @@ export default function GraphVolume({
 }
 
 GraphVolume.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/heart.jsx
+++ b/src/components/icon/icons/heart.jsx
@@ -6,10 +6,15 @@ export default function Heart({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g strokeWidth={strokeWidth} stroke={stroke}>
           <path
@@ -25,6 +30,7 @@ export default function Heart({
 }
 
 Heart.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/index.js
+++ b/src/components/icon/icons/index.js
@@ -1,0 +1,114 @@
+import Apartment from './apartment';
+import ArrowDown from './arrowDown';
+import ArrowLeft from './arrowLeft';
+import ArrowRight from './arrowRight';
+import ArrowUp from './arrowUp';
+import ArrowUpDown from './arrowUpDown';
+import Balloon from './balloon';
+import Bell from './bell';
+import Calendar from './calendar';
+import Cart from './cart';
+import Checkmark from './checkmark';
+import CheckmarkLarge from './checkmarkLarge';
+import ChevronDown from './chevronDown';
+import ChevronUp from './chevronUp';
+import CircleArrow from './circleArrow';
+import CircleSlash from './circleSlash';
+import Clock from './clock';
+import Close from './close';
+import Cloud from './cloud';
+import Edit from './edit';
+import Ellipsis from './ellipsis';
+import ExclamationPoint from './exclamationPoint';
+import Expand from './expand';
+import Film from './film';
+import Filter from './filter';
+import FloppyDisk from './floppyDisk';
+import Folder from './folder';
+import GraphArea from './graphArea';
+import GraphCandlestick from './graphCandlestick';
+import GraphLine from './graphLine';
+import GraphVolume from './graphVolume';
+import Heart from './heart';
+import Key from './key';
+import LightningBolt from './lightningBolt';
+import Lock from './lock';
+import Mail from './mail';
+import MailOpen from './mailOpen';
+import News from './news';
+import OrderDepth from './orderDepth';
+import Print from './print';
+import Profile from './profile';
+import Questionmark from './questionmark';
+import SearchIcon from './search';
+import Share from './share';
+import SignOut from './signOut';
+import SocialFacebook from './socialFacebook';
+import SocialGplus from './socialGplus';
+import SocialInstagram from './socialInstagram';
+import SocialTwitter from './socialTwitter';
+import Star from './star';
+import Tag from './tag';
+import TickingClock from './tickingClock';
+import Trash from './trash';
+import VerticalEllipsis from './verticalEllipsis';
+
+const Icon = {
+  Apartment,
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  ArrowUpDown,
+  Balloon,
+  Bell,
+  Calendar,
+  Cart,
+  Checkmark,
+  CheckmarkLarge,
+  ChevronDown,
+  ChevronUp,
+  CircleArrow,
+  CircleSlash,
+  Clock,
+  Close,
+  Cloud,
+  Edit,
+  Ellipsis,
+  ExclamationPoint,
+  Expand,
+  Film,
+  Filter,
+  FloppyDisk,
+  Folder,
+  GraphArea,
+  GraphCandlestick,
+  GraphLine,
+  GraphVolume,
+  Heart,
+  Key,
+  LightningBolt,
+  Lock,
+  Mail,
+  MailOpen,
+  News,
+  OrderDepth,
+  Print,
+  Profile,
+  Questionmark,
+  Search: SearchIcon,
+  Share,
+  SignOut,
+  SocialFacebook,
+  SocialGplus,
+  SocialInstagram,
+  SocialTwitter,
+  Star,
+  Tag,
+  TickingClock,
+  Trash,
+  VerticalEllipsis,
+};
+
+export default Icon;
+

--- a/src/components/icon/icons/index.test.js
+++ b/src/components/icon/icons/index.test.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { expect } from 'chai';
+// import { shallow as enzymeShallow } from 'enzyme';
+// import { createShallow } from '../../../src/test-utils';
+import Icons from './';
+
+describe('<Icon />', () => {
+  // const shallow = createShallow(enzymeShallow);
+
+  Icons.forEach(icon => {
+    it('should have pointerEvents set to none', () => {
+    expect(true);
+  });
+  })
+
+});

--- a/src/components/icon/icons/key.jsx
+++ b/src/components/icon/icons/key.jsx
@@ -6,10 +6,15 @@ export default function Key({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <circle cx="11" cy="5" r="0.5" />
@@ -27,6 +32,7 @@ export default function Key({
 }
 
 Key.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/lightningBolt.jsx
+++ b/src/components/icon/icons/lightningBolt.jsx
@@ -6,10 +6,15 @@ export default function LightningBolt({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <polygon fill={fill} points="9 2 4.5 9.5 7 9.5 7 14 11.5 6.5 9 6.5" />
         <path d="M7.4,1 C3.8,1.3 1,4.3 1,8 C1,10.8 2.6,13.2 5,14.3" stroke={stroke} strokeWidth={strokeWidth} />
@@ -20,6 +25,7 @@ export default function LightningBolt({
 }
 
 LightningBolt.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/lock.jsx
+++ b/src/components/icon/icons/lock.jsx
@@ -6,10 +6,15 @@ export default function Lock({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <rect strokeWidth={strokeWidth} x="3" y="6" width="10" height="9" />
@@ -26,6 +31,7 @@ export default function Lock({
 }
 
 Lock.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/mail.jsx
+++ b/src/components/icon/icons/mail.jsx
@@ -6,10 +6,15 @@ export default function Mail({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M1,3 L1,8 L1,13 L15,13 L15,8 L15,3 L1,3 Z" />
@@ -21,6 +26,7 @@ export default function Mail({
 }
 
 Mail.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/mailOpen.jsx
+++ b/src/components/icon/icons/mailOpen.jsx
@@ -6,10 +6,15 @@ export default function MailOpen({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M1,15 L1,5 L8,1.1499939 L15,5 L15,15 L1,15 Z" />
@@ -21,6 +26,7 @@ export default function MailOpen({
 }
 
 MailOpen.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/news.jsx
+++ b/src/components/icon/icons/news.jsx
@@ -6,10 +6,15 @@ export default function News({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <path d="M3.00000002,14 L13,14 C14.1,14 15,13.1 15,12 L15,2 L4,2 L4,6" strokeWidth={strokeWidth} />
@@ -29,6 +34,7 @@ export default function News({
 }
 
 News.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/orderDepth.jsx
+++ b/src/components/icon/icons/orderDepth.jsx
@@ -6,10 +6,15 @@ export default function OrderDepth({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g transform="translate(0, -3)" stroke={stroke}>
           <rect x="0.5" y="3.5" width="9" height="2" rx="0.7" />
@@ -22,6 +27,7 @@ export default function OrderDepth({
 }
 
 OrderDepth.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/print.jsx
+++ b/src/components/icon/icons/print.jsx
@@ -6,10 +6,15 @@ export default function Print({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <rect x="4" y="1" width="8" height="4" />
@@ -23,6 +28,7 @@ export default function Print({
 }
 
 Print.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/profile.jsx
+++ b/src/components/icon/icons/profile.jsx
@@ -6,10 +6,15 @@ export default function Profile({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -32,6 +37,7 @@ export default function Profile({
 }
 
 Profile.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/questionmark.jsx
+++ b/src/components/icon/icons/questionmark.jsx
@@ -6,10 +6,15 @@ export default function Questionmark({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <circle stroke={stroke} strokeWidth="1.71428571" cx="6" cy="6" r="6" />
         <path
@@ -25,6 +30,7 @@ export default function Questionmark({
 }
 
 Questionmark.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/search.jsx
+++ b/src/components/icon/icons/search.jsx
@@ -6,10 +6,15 @@ export default function Search({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -28,6 +33,7 @@ export default function Search({
 }
 
 Search.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/share.jsx
+++ b/src/components/icon/icons/share.jsx
@@ -6,10 +6,15 @@ export default function Share({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke}>
           <circle strokeWidth="1.5" cx="12.75" cy="3.25" r="2.5" />
@@ -24,6 +29,7 @@ export default function Share({
 }
 
 Share.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/signOut.jsx
+++ b/src/components/icon/icons/signOut.jsx
@@ -6,10 +6,15 @@ export default function SignOut({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -39,6 +44,7 @@ export default function SignOut({
 }
 
 SignOut.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/socialFacebook.jsx
+++ b/src/components/icon/icons/socialFacebook.jsx
@@ -6,10 +6,15 @@ export default function SocialFacebook({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <rect x="1" y="1" width="14" height="14" />
@@ -22,6 +27,7 @@ export default function SocialFacebook({
 }
 
 SocialFacebook.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/socialGplus.jsx
+++ b/src/components/icon/icons/socialGplus.jsx
@@ -6,10 +6,15 @@ export default function SocialGPlus({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M16,8 L10,8" fill={fill} />
@@ -24,6 +29,7 @@ export default function SocialGPlus({
 }
 
 SocialGPlus.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/socialInstagram.jsx
+++ b/src/components/icon/icons/socialInstagram.jsx
@@ -6,10 +6,15 @@ export default function SocialInstagram({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <rect x="1" y="1" width="14" height="14" />
@@ -24,6 +29,7 @@ export default function SocialInstagram({
 }
 
 SocialInstagram.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/socialTwitter.jsx
+++ b/src/components/icon/icons/socialTwitter.jsx
@@ -6,10 +6,15 @@ export default function SocialTwitter({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fill={fill}>
           <path
@@ -33,6 +38,7 @@ export default function SocialTwitter({
 }
 
 SocialTwitter.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/star.jsx
+++ b/src/components/icon/icons/star.jsx
@@ -6,10 +6,15 @@ export default function Star({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g strokeWidth={strokeWidth} stroke={stroke}>
           <path
@@ -24,6 +29,7 @@ export default function Star({
 }
 
 Star.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/tag.jsx
+++ b/src/components/icon/icons/tag.jsx
@@ -6,10 +6,15 @@ export default function Tag({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g stroke={stroke} strokeWidth={strokeWidth}>
           <path d="M1,1 L1,7 L8.5,14.5 L14.5,8.5 L7,1 L1,1 Z" />
@@ -21,6 +26,7 @@ export default function Tag({
 }
 
 Tag.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/tickingClock.jsx
+++ b/src/components/icon/icons/tickingClock.jsx
@@ -6,10 +6,15 @@ export default function TickingClock({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g transform="translate(1.000000, 1.000000)">
           <polyline stroke={stroke} strokeWidth={strokeWidth} points="7 4 7 7 9 9" />
@@ -26,6 +31,7 @@ export default function TickingClock({
 }
 
 TickingClock.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/trash.jsx
+++ b/src/components/icon/icons/trash.jsx
@@ -6,10 +6,15 @@ export default function Trash({
   stroke,
   fill,
   strokeWidth,
+  style: styleProp,
   ...rest // eslint-disable-line comma-dangle
 }) {
+  const style = {
+    ...styleProp,
+    ...Icon.defaultProps.style,
+  };
   return (
-    <svg {...rest}>
+    <svg style={style} {...rest}>
       <g stroke="none" strokeWidth={strokeWidth} fill="none" fillRule="evenodd">
         <g fillRule="nonzero" fill={fill}>
           <path
@@ -36,6 +41,7 @@ export default function Trash({
 }
 
 Trash.propTypes = {
+  ...Icon.propTypes,
   stroke: PropTypes.string,
   fill: PropTypes.string,
   strokeWidth: PropTypes.number,

--- a/src/components/icon/icons/verticalEllipsis.jsx
+++ b/src/components/icon/icons/verticalEllipsis.jsx
@@ -1,11 +1,13 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Ellipsis from './ellipsis';
+import Icon from '../icon';
 
 export default function VerticalEllipsis({ style: styleProp, ...rest }) {
   const style = {
     transform: 'rotate(0.25turn)',
     ...styleProp,
+    ...Icon.defaultProps.style,
   };
 
   return (

--- a/src/index.js
+++ b/src/index.js
@@ -21,61 +21,7 @@ import Tooltip from './components/tooltip';
 import Tr from './components/tr';
 import Ul from './components/ul/ul';
 
-// Icons
-import Apartment from './components/icon/icons/apartment';
-import ArrowDown from './components/icon/icons/arrowDown';
-import ArrowLeft from './components/icon/icons/arrowLeft';
-import ArrowRight from './components/icon/icons/arrowRight';
-import ArrowUp from './components/icon/icons/arrowUp';
-import ArrowUpDown from './components/icon/icons/arrowUpDown';
-import Balloon from './components/icon/icons/balloon';
-import Bell from './components/icon/icons/bell';
-import Calendar from './components/icon/icons/calendar';
-import Cart from './components/icon/icons/cart';
-import Checkmark from './components/icon/icons/checkmark';
-import CheckmarkLarge from './components/icon/icons/checkmarkLarge';
-import ChevronDown from './components/icon/icons/chevronDown';
-import ChevronUp from './components/icon/icons/chevronUp';
-import CircleArrow from './components/icon/icons/circleArrow';
-import CircleSlash from './components/icon/icons/circleSlash';
-import Clock from './components/icon/icons/clock';
-import Close from './components/icon/icons/close';
-import Cloud from './components/icon/icons/cloud';
-import Edit from './components/icon/icons/edit';
-import Ellipsis from './components/icon/icons/ellipsis';
-import ExclamationPoint from './components/icon/icons/exclamationPoint';
-import Expand from './components/icon/icons/expand';
-import Film from './components/icon/icons/film';
-import Filter from './components/icon/icons/filter';
-import FloppyDisk from './components/icon/icons/floppyDisk';
-import Folder from './components/icon/icons/folder';
-import GraphArea from './components/icon/icons/graphArea';
-import GraphCandlestick from './components/icon/icons/graphCandlestick';
-import GraphLine from './components/icon/icons/graphLine';
-import GraphVolume from './components/icon/icons/graphVolume';
-import Heart from './components/icon/icons/heart';
-import Key from './components/icon/icons/key';
-import LightningBolt from './components/icon/icons/lightningBolt';
-import Lock from './components/icon/icons/lock';
-import Mail from './components/icon/icons/mail';
-import MailOpen from './components/icon/icons/mailOpen';
-import News from './components/icon/icons/news';
-import OrderDepth from './components/icon/icons/orderDepth';
-import Print from './components/icon/icons/print';
-import Profile from './components/icon/icons/profile';
-import Questionmark from './components/icon/icons/questionmark';
-import SearchIcon from './components/icon/icons/search';
-import Share from './components/icon/icons/share';
-import SignOut from './components/icon/icons/signOut';
-import SocialFacebook from './components/icon/icons/socialFacebook';
-import SocialGplus from './components/icon/icons/socialGplus';
-import SocialInstagram from './components/icon/icons/socialInstagram';
-import SocialTwitter from './components/icon/icons/socialTwitter';
-import Star from './components/icon/icons/star';
-import Tag from './components/icon/icons/tag';
-import TickingClock from './components/icon/icons/tickingClock';
-import Trash from './components/icon/icons/trash';
-import VerticalEllipsis from './components/icon/icons/verticalEllipsis';
+import Icon from './components/icon/icons';
 
 // Theming
 import { ThemeProvider, createTheme } from './styles';
@@ -88,63 +34,6 @@ import {
 } from './test-utils';
 
 const theme = createTheme();
-
-const Icon = {
-  Apartment,
-  ArrowDown,
-  ArrowLeft,
-  ArrowRight,
-  ArrowUp,
-  ArrowUpDown,
-  Balloon,
-  Bell,
-  Calendar,
-  Cart,
-  Checkmark,
-  CheckmarkLarge,
-  ChevronDown,
-  ChevronUp,
-  CircleArrow,
-  CircleSlash,
-  Clock,
-  Close,
-  Cloud,
-  Edit,
-  Ellipsis,
-  ExclamationPoint,
-  Expand,
-  Film,
-  Filter,
-  FloppyDisk,
-  Folder,
-  GraphArea,
-  GraphCandlestick,
-  GraphLine,
-  GraphVolume,
-  Heart,
-  Key,
-  LightningBolt,
-  Lock,
-  Mail,
-  MailOpen,
-  News,
-  OrderDepth,
-  Print,
-  Profile,
-  Questionmark,
-  Search: SearchIcon,
-  Share,
-  SignOut,
-  SocialFacebook,
-  SocialGplus,
-  SocialInstagram,
-  SocialTwitter,
-  Star,
-  Tag,
-  TickingClock,
-  Trash,
-  VerticalEllipsis,
-};
 
 export {
   Alert,

--- a/test/components/icon/icon.test.js
+++ b/test/components/icon/icon.test.js
@@ -31,4 +31,14 @@ describe('<Icon />', () => {
     wrapper = shallow(<Icon.Trash fill={color} />);
     expect(wrapper.find('g > g').prop('fill')).to.equal(color);
   });
+
+  it('should have pointerEvents set to none', () => {
+    Object.keys(Icon).map((key) => {
+      const Component = Icon[key];
+      const element = shallow(<Component />);
+      // If a test breaks, uncomment this to see which icon is broken:
+      // console.log(`${key}: ${element.props().style.pointerEvents}`);
+      return expect(element.props().style.pointerEvents).to.equal('none');
+    });
+  });
 });


### PR DESCRIPTION
We have some strange error where icons inside react-router <Link /> components are not clickable.
By setting pointer-events to none the event bubbles up to the parent.

Also moved some boilerplate from index.js to icon/index.js.