### PR TITLE
fix(Button): Update button color 

### DIFF
--- a/src/components/button/button-styles.jsx
+++ b/src/components/button/button-styles.jsx
@@ -108,13 +108,13 @@ export default createStyleSheet('Button', theme => {
     },
 
     primary: {
-      background: palette.background.secondary,
-      border: `2px solid ${palette.background.secondary}`,
+      background: palette.color.gray,
+      border: `2px solid ${palette.color.gray}`,
       color: palette.shades.dark.text.default,
 
       '&:hover': {
-        background: focusColor(palette.background.secondary),
-        borderColor: focusColor(palette.background.secondary),
+        background: focusColor(palette.color.gray),
+        borderColor: focusColor(palette.color.gray),
       },
 
       '&:disabled': {
@@ -214,13 +214,13 @@ export default createStyleSheet('Button', theme => {
       background: 'none',
       paddingLeft: 0,
       paddingRight: 0,
-      color: palette.background.secondary,
+      color: palette.color.gray,
       border: '2px solid transparent',
       fontWeight: 600,
       cursor: 'pointer',
 
       '&:hover': {
-        color: c(palette.background.secondary).darken(0.2).hex(), // was $color-primary-dark
+        color: c(palette.color.gray).darken(0.2).hex(),
       },
 
       '&:disabled': {


### PR DESCRIPTION
Update button color for primary and link case to be more consistent with secondary.

Before:
![screen shot 2017-05-17 at 16 58 10](https://cloud.githubusercontent.com/assets/1844083/26160758/678310e6-3b22-11e7-8fe1-f5f358c0f701.png)


After:
![screen shot 2017-05-17 at 16 58 19](https://cloud.githubusercontent.com/assets/1844083/26160766/6ae1fc84-3b22-11e7-8379-e87c3f85ddbb.png)

