### PR TITLE
fix(Button): Remove button text animation in IE

### DIFF
--- a/src/components/button/button-styles.jsx
+++ b/src/components/button/button-styles.jsx
@@ -80,6 +80,10 @@ export default createStyleSheet('Button', theme => {
       userSelect: 'none',
       textAlign: 'center',
 
+      '& > span': {
+        position: 'relative',
+      },
+
       '&:disabled': {
         cursor: 'not-allowed',
       },

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -32,7 +32,9 @@ function Button({ variant, block, disabled, className, children, modifier, href,
 
   return (
     <Element {...rest} className={usedClassName} disabled={disabled} href={href}>
-      {children}
+      <span>
+        {children}
+      </span>
     </Element>
   );
 }


### PR DESCRIPTION
Add a span with position relative to workaround IE specific focus "animation"