### PR TITLE
Animate enhancement

### DIFF
--- a/src/components/animate/animate.jsx
+++ b/src/components/animate/animate.jsx
@@ -9,17 +9,15 @@ import easings from '../../styles/transitions/easings';
 class Animate extends React.PureComponent {
   constructor(props, context) {
     super(props, context);
-    this.idNbr = Math.round(Math.random() * 1000);
-    this.animationName = `${this.props.type}-animation-${this.idNbr}`;
     this.classes = this.context.styleManager.render(
-      createStyleSheet(`Animate_${this.animationName}`, () => {
+      createStyleSheet(`Animate-${props.animationName}`, () => {
         switch (this.props.type) {
           case 'height':
             return {
               root: {
                 ...modifierHeight({
                   classPrefixSpace: true,
-                  name: this.animationName,
+                  name: props.animationName,
                   estimatedHeight: this.props.estimatedHeight,
                   transitionEnterTimeout: this.props.enterTime,
                   transitionLeaveTimeout: this.props.leaveTime,
@@ -36,10 +34,14 @@ class Animate extends React.PureComponent {
   }
 
   render() {
+    if (!this.props.animationName) {
+      // Force users to set animationName to render anything
+      return null;
+    }
     return (
       <CSSTransitionGroup
         className={cn(this.classes.root, this.props.className)}
-        transitionName={this.animationName}
+        transitionName={this.props.animationName}
         transitionEnterTimeout={this.props.enterTime}
         transitionLeaveTimeout={this.props.leaveTime}
       >
@@ -52,6 +54,7 @@ class Animate extends React.PureComponent {
 Animate.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  animationName: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['height']).isRequired,
   enterTime: PropTypes.number.isRequired,
   leaveTime: PropTypes.number.isRequired,

--- a/src/components/animate/animate.jsx
+++ b/src/components/animate/animate.jsx
@@ -45,7 +45,7 @@ class Animate extends React.PureComponent {
         transitionEnterTimeout={this.props.enterTime}
         transitionLeaveTimeout={this.props.leaveTime}
       >
-        {this.props.children}
+        {this.props.children ? <div>{this.props.children}</div> : null}
       </CSSTransitionGroup>
     );
   }
@@ -54,6 +54,7 @@ class Animate extends React.PureComponent {
 Animate.propTypes = {
   children: PropTypes.node,
   className: PropTypes.string,
+  /** This needs to be set in order for the component to render anything */
   animationName: PropTypes.string.isRequired,
   type: PropTypes.oneOf(['height']).isRequired,
   enterTime: PropTypes.number.isRequired,

--- a/src/components/animate/modifierHeight.js
+++ b/src/components/animate/modifierHeight.js
@@ -11,7 +11,7 @@ export default ({
   easingLeaveFunction = easings.easeOut,
 }) => ({
   overflow: 'hidden',
-  maxHeight: 'auto',
+  maxHeight: 'none',
 
   [`&${classPrefixSpace ? ' ' : ''}.${name}`]: {
     '&-enter': {

--- a/src/components/animate/modifierHeight.js
+++ b/src/components/animate/modifierHeight.js
@@ -11,7 +11,12 @@ export default ({
   easingLeaveFunction = easings.easeOut,
 }) => ({
   overflow: 'hidden',
-  maxHeight: 'none',
+  boxSizing: 'border-box',
+
+  '& > div': {
+    overflow: 'hidden',
+    boxSizing: 'border-box',
+  },
 
   [`&${classPrefixSpace ? ' ' : ''}.${name}`]: {
     '&-enter': {

--- a/test/components/animate/animate.test.js
+++ b/test/components/animate/animate.test.js
@@ -13,7 +13,7 @@ describe('<Animate />', () => {
 
   beforeEach(() => {
     topWrapper = shallow(
-      <Animate>
+      <Animate animationName="testAnimationName">
         {inputText}
       </Animate>,
     );
@@ -28,15 +28,8 @@ describe('<Animate />', () => {
     expect(wrapper.text()).to.equal(inputText);
   });
 
-  it('should give a unique identifier to each Animate instance', () => {
-    const transitionName = topWrapper.prop('transitionName');
-    const otherWrapper = shallow(
-      <Animate>
-        {inputText}
-      </Animate>,
-    );
-
-    const otherTransitionName = otherWrapper.prop('transitionName');
-    expect(transitionName).to.not.equal(otherTransitionName);
+  it('should require an animationName to render', () => {
+    const otherWrapper = shallow(<Animate>{inputText}</Animate>);
+    expect(otherWrapper.html()).to.equal(null);
   });
 });


### PR DESCRIPTION
Two things solved in this PR:

* Require prop "animationName" when creating an Animate. 
* Add wrapping div around children of Animate to solve the problem when the children has top or bottom padding

Side effect: Now we should only have single child in each Animate.
