### PR TITLE
fix(Table): 💄 Make horizontal scrolling work on iOS devices

### DIFF
--- a/src/components/table/table-styles.jsx
+++ b/src/components/table/table-styles.jsx
@@ -9,6 +9,11 @@ export default createStyleSheet('Table', theme => {
       width: '100%',
       overflow: 'auto',
       position: 'relative',
+
+      '@supports (-webkit-overflow-scrolling: touch)': {
+        overflow: 'scroll',
+        '-webkit-overflow-scrolling': 'touch',
+      },
     },
     table: {
       ...mixins.basicBoxSizing,

--- a/src/components/tbody/tbody-styles.jsx
+++ b/src/components/tbody/tbody-styles.jsx
@@ -10,10 +10,15 @@ export default createStyleSheet('Tbody', theme => {
       ...styleUtils.sizes(),
       ...styleUtils.borders(palette),
       width: '100%',
+      overflow: 'auto',
       maxHeight: '70vh',
-      overflowY: 'auto',
 
-      [mixins.media('sm')]: {
+      '@supports (-webkit-overflow-scrolling: touch)': {
+        overflow: 'scroll',
+        '-webkit-overflow-scrolling': 'touch',
+      },
+
+      [mixins.media('md')]: {
         maxHeight: '100%',
       },
 

--- a/src/components/td/td-styles.jsx
+++ b/src/components/td/td-styles.jsx
@@ -22,7 +22,7 @@ export default createStyleSheet('Td', theme => {
       paddingTop: 8,
       paddingBottom: 8,
 
-      [mixins.media('sm')]: {
+      [mixins.media('md')]: {
         fontSize: 14,
         minWidth: 40,
         paddingTop: 20,

--- a/src/components/th/th-styles.jsx
+++ b/src/components/th/th-styles.jsx
@@ -20,7 +20,7 @@ export default createStyleSheet('Th', theme => {
       minWidth: 20,
       paddingBottom: 4,
 
-      [mixins.media('sm')]: {
+      [mixins.media('md')]: {
         minWidth: 40,
         paddingBottom: 10,
       },

--- a/src/components/thead/thead-styles.jsx
+++ b/src/components/thead/thead-styles.jsx
@@ -18,7 +18,7 @@ export default createStyleSheet('Thead', theme => {
       fontSize: 12,
       paddingBottom: 4,
 
-      [mixins.media('sm')]: {
+      [mixins.media('md')]: {
         paddingBottom: 10,
       },
 

--- a/src/components/tr/tr-styles.jsx
+++ b/src/components/tr/tr-styles.jsx
@@ -34,7 +34,7 @@ export default createStyleSheet('Tr', theme => {
         background: palette.background.default,
       },
 
-      [mixins.media('sm')]: {
+      [mixins.media('md')]: {
         '&.sticky': {
           position: 'fixed',
         },


### PR DESCRIPTION
* Change breakpoint from sm to md
* Change overflow to scroll instead of auto on iOS
* Add -webkit-overflow-scrolling: touch to make scrolling smoother on
iOS