### PR TITLE
fix(Input): Remove out-of-sync marginBottom from input field in focus

### DIFF
--- a/src/components/input/input-default-styles.jsx
+++ b/src/components/input/input-default-styles.jsx
@@ -70,7 +70,6 @@ export default createStyleSheet('InputDefault', theme => {
       },
 
       '&.input--has-focus': {
-        marginBottom: inputMarginBottom,
         '& .input': {
           '&__label': {
             color: palette.action.active,


### PR DESCRIPTION
This created a bug in webapp-next when changing focus on the Search input field