### PR TITLE
fix(Animate): SHEL-167 Animate component. Use height as well as max-height

### DIFF
--- a/src/components/animate/modifierHeight.js
+++ b/src/components/animate/modifierHeight.js
@@ -15,22 +15,26 @@ export default ({
 
   [`&${classPrefixSpace ? ' ' : ''}.${name}`]: {
     '&-enter': {
+      height: 0,
       maxHeight: 0,
 
       [`&.${name}-enter-active`]: {
+        height: estimatedHeight,
         maxHeight: estimatedHeight,
         transitionTimingFunction: easingEnterFunction,
-        transitionProperty: 'max-height',
+        transitionProperty: 'max-height, height',
         transitionDuration: transitionEnterTimeout,
       },
     },
     '&-leave': {
+      height: estimatedHeight,
       maxHeight: estimatedHeight,
       transitionTimingFunction: easingLeaveFunction,
-      transitionProperty: 'max-height',
+      transitionProperty: 'max-height, height',
       transitionDuration: transitionLeaveTimeout,
 
       [`&.${name}-leave-active`]: {
+        height: 0,
         maxHeight: 0,
       },
     },


### PR DESCRIPTION
Use height as well as max-height. This makes the animation stutter less in Firefox. Less work calculating reflows during animation.