### PR TITLE
feat(Alert Component): add dismissedCallback prop

### DIFF
--- a/src/components/alert/alert.jsx
+++ b/src/components/alert/alert.jsx
@@ -23,6 +23,7 @@ class Alert extends React.PureComponent {
     this.setState({
       dismissed: true,
     });
+    this.props.dismissedCallback();
   }
 
   renderClose() {
@@ -76,6 +77,7 @@ Alert.propTypes = {
   vertical: PropTypes.bool,
   dismissable: PropTypes.bool,
   dismissed: PropTypes.bool,
+  dismissedCallback: PropTypes.func,
 };
 
 Alert.defaultProps = {
@@ -83,6 +85,7 @@ Alert.defaultProps = {
   vertical: false,
   dismissable: true,
   dismissed: false,
+  dismissedCallback: () => {},
 };
 
 export { Alert as Component, styles };

--- a/test/components/alert/alert.test.js
+++ b/test/components/alert/alert.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
+import sinon from 'sinon';
 import { Component as Alert, styles } from '../../../src/components/alert/alert';
 import { mockClasses, theme } from '../../../src';
 
@@ -58,5 +59,18 @@ describe('<Alert />', () => {
     wrapper.setProps({ dismissable: false });
     const actual = wrapper.find(`button.${classes.close}`).exists();
     expect(actual).to.equal(false);
+  });
+
+  it('should call dismissedCallback when dismissed', () => {
+    const spy = sinon.spy();
+    const wrapper = shallow(<Alert {...defaultProps} dismissedCallback={spy}>body</Alert>);
+    wrapper.find(`button.${classes.close}`).simulate('click');
+    expect(spy.calledOnce).to.equal(true);
+  });
+
+  it('should not call dismissedCallback when not dismissed', () => {
+    const spy = sinon.spy();
+    shallow(<Alert {...defaultProps} dismissedCallback={spy}>body</Alert>);
+    expect(spy.called).to.equal(false);
   });
 });


### PR DESCRIPTION
add dismissedCallback prop so that consumers can know when the component has been dismissed