### PR TITLE
feat(<Pane />): make it possible to change active tab from outside

### DIFF
--- a/src/components/pane/pane.jsx
+++ b/src/components/pane/pane.jsx
@@ -10,12 +10,20 @@ class Pane extends React.PureComponent {
   constructor(props, context) {
     super(props, context);
     this.state = {
-      activeTab: props.activeTab || 0,
+      activeTab: props.activeTab,
     };
 
     this.handleTabClick = this.handleTabClick.bind(this);
 
     this.classes = this.props.classes;
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if (this.props.activeTab !== nextProps.activeTab && nextProps.activeTab !== this.state.activeTab) {
+      this.setState({
+        activeTab: nextProps.activeTab,
+      });
+    }
   }
 
   handleTabClick(index) {
@@ -93,6 +101,7 @@ Pane.propTypes = {
 
 Pane.defaultProps = {
   size: 'md',
+  activeTab: 0,
 };
 
 export { Pane as Component, styles };

--- a/test/components/pane/pane.test.js
+++ b/test/components/pane/pane.test.js
@@ -61,6 +61,17 @@ describe('<Pane />', () => {
     it('default size should be md', () => {
       expect(renderedTabs.at(0).hasClass(classes.md)).to.equal(true);
     });
+
+    it('should change active tab on activeTab prop change', () => {
+      wrapper.setProps({ activeTab: 1 });
+      expect(renderedTabs.at(1).hasClass(classes.active));
+    });
+
+    it('should not change active tab if component gets props unrelated to active tab', () => {
+      wrapper.setState({ activeTab: 2 });
+      wrapper.setProps({ size: 'lg' });
+      expect(renderedTabs.at(2).hasClass(classes.active));
+    });
   });
 
   describe('When <Pane /> is correctly populated with another size', () => {


### PR DESCRIPTION
component is now listening to prop change of activeTab prop, making it possible but not required to
handle the component tab state from outside.