### PR TITLE
feat(ProgressBar): add 'highlightActive' option

### DIFF
--- a/src/components/progress-bar/progress-bar-styles.jsx
+++ b/src/components/progress-bar/progress-bar-styles.jsx
@@ -123,6 +123,7 @@ export default theme => {
     },
 
     reached: {},
+    active: {},
 
     primary: {
       ...variantModifierFn('primary', {
@@ -138,6 +139,11 @@ export default theme => {
         borderColor: palette.shades.dark.background.default,
         color: palette.shades.dark.text.default,
         colorDisabled: palette.shades.dark.text.muted,
+      }),
+
+      '&$active': variantModifierFn('primary', {
+        background: palette.action.active,
+        borderColor: palette.action.active,
       }),
     },
 
@@ -155,6 +161,11 @@ export default theme => {
         borderColor: palette.shades.dark.background.default,
         color: palette.shades.dark.text.default,
         colorDisabled: palette.shades.dark.text.muted,
+      }),
+
+      '&$active': variantModifierFn('secondary', {
+        background: palette.action.active,
+        borderColor: palette.action.active,
       }),
     },
   };

--- a/src/components/progress-bar/progress-bar.jsx
+++ b/src/components/progress-bar/progress-bar.jsx
@@ -13,6 +13,7 @@ function ProgressBar({
   value,
   max,
   printNumbers,
+  highlightActive,
   clickables,
   theme, // eslint-disable-line react/prop-types
   sheet, // eslint-disable-line react/prop-types
@@ -37,12 +38,13 @@ function ProgressBar({
       <div aria-hidden={clickables.length === 0 ? 'true' : 'false'} className={classNames(classes.progressBar)}>
         {_times(max, i => {
           const Element = getElementType(clickables[i]);
-          const { label, reached, ...clickablesRest } = clickables[i] || {};
+          const { label, reached, active, ...clickablesRest } = clickables[i] || {};
           const elementClassNames = classNames(classes.progressStep, {
             [classes.clickable]: Element !== 'span',
             [classes.primary]: isPrimary,
             [classes.secondary]: isSecondary,
             [classes.reached]: typeof reached !== 'undefined' ? reached : i < value,
+            [classes.active]: typeof active !== 'undefined' ? active : highlightActive && i === value - 1,
           });
 
           return (
@@ -63,6 +65,7 @@ ProgressBar.defaultProps = {
   size: 'xs',
   value: 0,
   printNumbers: false,
+  highlightActive: false,
   clickables: [],
 };
 
@@ -78,6 +81,8 @@ ProgressBar.propTypes = {
   max: PropTypes.number.isRequired,
   /** Print a number for each step */
   printNumbers: PropTypes.bool,
+  /** Highlight the active (current) value */
+  highlightActive: PropTypes.bool,
   /** Experimental: For each step you can override the label and status, and make it clickable. See advanced examples for inspiration. */
   clickables: PropTypes.arrayOf(PropTypes.object),
 };

--- a/src/components/progress-bar/progress-bar.md
+++ b/src/components/progress-bar/progress-bar.md
@@ -22,7 +22,8 @@ Advanced (experimental):
       { label: 'A', reached: true, href: '/foo/bar', title: 'A tag' },
       { label: 'B', reached: false, onClick: () => alert('hej'), title: 'BUTTON tag' },
       { label: 'C', reached: true, disabled: true, title: 'Disabled' },
-      { label: 'D', reached: false,  disabled: true, title: 'Disabled' },
+      { label: 'D', reached: false, disabled: true, title: 'Disabled' },
+      { label: 'E', reached: true, active: true, title: 'Active' },
     ];
 
     <div>

--- a/test/components/progress-bar/progress-bar.test.js
+++ b/test/components/progress-bar/progress-bar.test.js
@@ -54,6 +54,18 @@ describe('<ProgressBar />', () => {
     });
   });
 
+  it('should not highlight the active step by default', () => {
+    wrapper = shallow(<ProgressBar classes={classes} value={value} max={max} />);
+    expect(wrapper.find('.progressBar .active').length).to.equal(0);
+    expect(wrapper.find('.progressBar').childAt(value - 1).hasClass('active')).to.equal(false);
+  });
+
+  it('should be possible to highlight the active step', () => {
+    wrapper = shallow(<ProgressBar classes={classes} value={value} max={max} highlightActive />);
+    expect(wrapper.find('.progressBar .active').length).to.equal(1);
+    expect(wrapper.find('.progressBar').childAt(value - 1).hasClass('active')).to.equal(true);
+  });
+
   ['primary', 'secondary'].forEach(variant => {
     it(`should have class ${classes[variant]} if variant is set to ${variant}`, () => {
       wrapper = shallow(<ProgressBar classes={classes} variant={variant} value={value} max={max} />);
@@ -81,6 +93,11 @@ describe('<ProgressBar />', () => {
     wrapper = shallow(<ProgressBar classes={classes} value={value} max={max} clickables={[{ reached: false }]} />);
     expect(wrapper.find('.progressBar').childAt(0).hasClass('reached')).to.equal(false);
     expect(wrapper.find('.progressBar').childAt(1).hasClass('reached')).to.equal(true);
+  });
+
+  it('should be possible to override the active class for a specific step', () => {
+    wrapper = shallow(<ProgressBar classes={classes} value={value} max={max} clickables={[{ active: true }]} />);
+    expect(wrapper.find('.progressBar').childAt(0).hasClass('reached')).to.equal(true);
   });
 
   it('should be possible to override the label class for a specific step', () => {


### PR DESCRIPTION
Setting the **highlightActive** property will highlight the active (current) value, so that the user can clearly see which step they are currently at.

![image](https://user-images.githubusercontent.com/3064403/32177240-12525eac-bd8a-11e7-97cc-39b4088fb6ad.png)
