### PR TITLE
Feature/tooltip dont calc placement if given

### DIFF
--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -146,7 +146,7 @@ class Tooltip extends React.Component {
   render() {
     const { children, content, className, placement, style, tooltipStyle } = this.props;
     if (this.container && this.popup && this.state.hover) {
-      this.placement = this.getPlacement(placement);
+      this.placement = placement || this.getPlacement(placement);
 
       const rect = this.container.getBoundingClientRect();
       this.contentHeight = (rect.height || 0) - 3;

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -45,6 +45,15 @@
       </li>
 
       <li style={{marginBottom: '11px'}}>
+        <span>No placement given:</span>
+        <Tooltip content="The component found out the best placement for me!"><span style={{fontSize: '30px'}}>Hello world!</span></Tooltip>
+        <span> ••• </span>
+        <Tooltip content="The component found out the best placement for me!"><span>Hello world!</span></Tooltip>
+        <span> ••• </span>
+        <Tooltip content={ <span>The component found out the best placement for me!</span> } />
+      </li>
+
+      <li style={{marginBottom: '11px'}}>
         <span>This Tooltip contains some HTML:</span>
         <Tooltip content={ <span>This is a <u>span</u>!</span> } />
       </li>

--- a/test/components/tooltip/tooltip.test.js
+++ b/test/components/tooltip/tooltip.test.js
@@ -63,6 +63,12 @@ describe('<Tooltip />', () => {
     expect(wrapper.find(`.${classes.popup}`).hasClass('left')).to.equal(true);
   });
 
+  it('should set placement to below if none is given', () => {
+    wrapper = shallow(<Tooltip classes={classes} content="Lorem ipsum dolor sit amet." />);
+    wrapper.find(`.${classes.container}`).simulate('mouseEnter');
+    expect(wrapper.find(`.${classes.popup}`).hasClass('below')).to.equal(true);
+  });
+
   describe('click outside functionality', () => {
     const target = { attachTo: document.getElementById('app') };
     let component;


### PR DESCRIPTION
We had an issue where we gave a placement and visually it looked like that placement would work fine, but in the end another one was calculated by the component. Discussed briefly that maybe we should always use the given placement and only calculate when none is given. 

Shout out if anyone sees any problems with this. 