### PR TITLE
feat(front-end): Changed proptype for radio label

### DIFF
--- a/src/components/input/input-checkbox-radio.jsx
+++ b/src/components/input/input-checkbox-radio.jsx
@@ -131,7 +131,7 @@ InputCheckboxRadio.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
   value: PropTypes.string,
-  label: PropTypes.string,
+  label: PropTypes.node,
   onChange: PropTypes.func,
   hasSuccess: PropTypes.bool,
   hasError: PropTypes.bool,


### PR DESCRIPTION
Changed proptype for label in input-checkobox-radio from string to node