### PR TITLE
fix(Input): Reset input padding applied by some browsers

### DIFF
--- a/src/components/input/input-default-styles.jsx
+++ b/src/components/input/input-default-styles.jsx
@@ -164,6 +164,7 @@ export default theme => {
         fontFamily: 'inherit',
         fontWeight: 'inherit',
         minWidth: 0,
+        padding: 0,
 
         '&:focus': {
           outline: 'none',


### PR DESCRIPTION
Set padding to 0 to prevent different input types having different browser-dependent default
paddings.

Before:
![image](https://user-images.githubusercontent.com/3064403/32784983-a053deac-c950-11e7-9538-59e1be5974fd.png)

After:
![image](https://user-images.githubusercontent.com/3064403/32785009-b53fd726-c950-11e7-9664-57a5853aff35.png)
