### PR TITLE
fix(Input): Reset input padding and set height

### DIFF
--- a/src/components/input/input-default-styles.jsx
+++ b/src/components/input/input-default-styles.jsx
@@ -160,10 +160,11 @@ export default theme => {
         width: '100%',
         transition: transitions.create(['border-color', 'transform']),
         fontSize: 14,
-        maxHeight: 27,
+        height: '1.5em',
         fontFamily: 'inherit',
         fontWeight: 'inherit',
         minWidth: 0,
+        padding: 0,
 
         '&:focus': {
           outline: 'none',


### PR DESCRIPTION
Set padding to 0 and define a height in order to make inputs have the same
height across browsers. Here are before-and-after screenshots from Chrome, Firefox and Internet Explorer:

![image](https://user-images.githubusercontent.com/3064403/32791293-fa7810d2-c960-11e7-81f0-325cafdd94fc.png)

The red lines are absolute-positioned behind the inputs to illustrate the difference between before (left column) and after (right column).