### PR TITLE
refactor(input[textarea]): Move style into CSS file

### DIFF
--- a/src/components/input/input-default-styles.jsx
+++ b/src/components/input/input-default-styles.jsx
@@ -171,6 +171,7 @@ export default theme => {
         '&--textarea': {
           maxHeight: 'none',
           resize: 'vertical',
+          height: ({ lineCount }) => `${lineCount * 1.5}em`,
         },
       },
 

--- a/src/components/input/input-default.jsx
+++ b/src/components/input/input-default.jsx
@@ -102,6 +102,7 @@ class InputDefault extends React.PureComponent {
   renderInput(id) {
     const classes = `input__element input__element--${this.props.type}`;
     const placeholder = this.props.placeholder || this.props.label;
+    const Tag = this.props.type === 'textarea' ? 'textarea' : 'input';
 
     const props = {
       ...omit(
@@ -129,11 +130,7 @@ class InputDefault extends React.PureComponent {
       value: this.state.value,
     };
 
-    if (this.props.type === 'textarea') {
-      return <textarea {...props} style={{ height: this.props.lineCount * 21 }} />;
-    }
-
-    return <input {...props} />;
+    return <Tag {...props} />;
   }
 
   renderLabel(id) {
@@ -226,7 +223,7 @@ InputDefault.propTypes = {
   leftAddon: PropTypes.node,
   rightAddon: PropTypes.node,
   /** Only used when type === textarea */
-  lineCount: PropTypes.number,
+  lineCount: PropTypes.number, // eslint-disable-line
 };
 
 InputDefault.defaultProps = {


### PR DESCRIPTION
This should've been in the previous PR, but it was merged before I managed to push. Theoretically this is a breaking change, since we change from `px` to `em`. But I know for a fact that nobody uses this component yet, so IMO we can label this as a refactor and skip the release.