### PR TITLE
fix(Spinner): wrapper as a span to avoid console errors

### DIFF
--- a/src/components/spinner/spinner.jsx
+++ b/src/components/spinner/spinner.jsx
@@ -79,7 +79,7 @@ function Spinner({
   };
 
   return (
-    <div {...rest} className={classNames(classes.spinner, className)} style={wrapperStyle}>
+    <span {...rest} className={classNames(classes.spinner, className)} style={wrapperStyle}>
       <svg className={classes.element} viewBox={`0 0 ${size} ${size}`}>
         <defs>
           <clipPath id={clipPathId}>
@@ -94,7 +94,7 @@ function Spinner({
         </defs>
         <g dangerouslySetInnerHTML={renderCircleAsHtml(radius, usedColor, maskId)} />
       </svg>
-    </div>
+    </span>
   );
 }
 

--- a/test/components/spinner/spinner.test.js
+++ b/test/components/spinner/spinner.test.js
@@ -12,8 +12,8 @@ describe('<Spinner />', () => {
     wrapper = shallow(<Spinner classes={classes} theme={theme} />);
   });
 
-  it('should render <div> as container', () => {
-    expect(wrapper.type()).to.equal('div');
+  it('should render <span> as container', () => {
+    expect(wrapper.type()).to.equal('span');
   });
 
   it(`should have the class ${classes.spinner}`, () => {


### PR DESCRIPTION
This avoids:
```
Warning: validateDOMNesting(...): <div> cannot appear as a descendant of <p>.
    in div
    in Spinner (created by Jss(Spinner))
```
when using us a spinner inside of certain elements. The spinner is already set to `inline-block` so this should have no downstream effects.