### PR TITLE
fix(Tooltip): Prevent tooltip from going off screen on mobile

### DIFF
--- a/documentation/template.html
+++ b/documentation/template.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8">
 		<title><%=htmlWebpackPlugin.options.title%></title>
     <link href="https://fonts.googleapis.com/css?family=Bitter:400,700|Open+Sans:300,400,600,700,800" rel="stylesheet">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
 	</head>
 	<body>
 		<div id="app"></div>

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -123,10 +123,14 @@ class Tooltip extends React.Component {
         const popupRect = this.popup.getBoundingClientRect();
         const adjustedLeft = popupRect.left - this.left;
         const adjustedRight = popupRect.right - this.left;
+
+        const pxDiff = Math.min(window.innerWidth - popupRect.width, 20);
+        const gutter = pxDiff > 0 ? pxDiff / 2 : 0;
+
         if (adjustedLeft < 0) {
-          this.left = 10 - adjustedLeft;
+          this.left = gutter - adjustedLeft;
         } else if (adjustedRight > window.innerWidth) {
-          this.left = -(adjustedRight - window.innerWidth + 10);
+          this.left = window.innerWidth - adjustedRight - gutter;
         } else {
           this.left = 0;
         }


### PR DESCRIPTION
Solves the case when a tooltip should fit (although barely) but gets rendered off screen. This happens since:
1. The default space from the edge (10) is to big
2. The meta viewport tag is invalid, which makes `window.innerWidth` to behave badly.

Fixes #339 
