### PR TITLE
fix(tooltip): color should inherit from parent as all icons do

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tmp
 .tmp
 coverage
 .nyc_output
+.idea

--- a/src/components/tooltip/tooltip-styles.jsx
+++ b/src/components/tooltip/tooltip-styles.jsx
@@ -6,7 +6,7 @@ export default theme => {
   return {
     tooltip: {
       ...mixins.basicBoxSizing,
-      color: palette.variant.primary,
+      color: palette.color.grayDarker,
       position: 'relative',
       display: 'inline-block',
     },

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -198,7 +198,7 @@ class Tooltip extends React.Component {
 }
 
 Tooltip.defaultProps = {
-  children: <Questionmark fill="#6A6775" stroke="#6A6775" width={16} height={16} />,
+  children: <Questionmark width={16} height={16} />,
   placement: 'below',
   sticky: true,
 };


### PR DESCRIPTION
With the change that was made to icons they are now set to inherit from their color from their parent. This syncs that same behavior.

I'm following up with design for if words/svgs should have any color when they have a tooltip and will handle that separately if it changes.