### PR TITLE
fix(table): Add limited width example and never allow the table cells to touch

### DIFF
--- a/src/components/table-cell/table-cell-styles.jsx
+++ b/src/components/table-cell/table-cell-styles.jsx
@@ -14,7 +14,7 @@ export default theme => {
       fontFamily: typography.primary.fontFamily,
       fontWeight: 'inherit',
 
-      padding: 0,
+      padding: 8,
       fontSize: 14,
       minWidth: 20,
       maxHeight: 50,
@@ -63,7 +63,6 @@ export default theme => {
     },
     child: {
       display: 'block',
-      margin: [8, 0],
       height: 'calc(100% - 16px)',
 
       '&::before': {

--- a/src/components/table-cell/table-cell-styles.jsx
+++ b/src/components/table-cell/table-cell-styles.jsx
@@ -14,8 +14,7 @@ export default theme => {
       fontFamily: typography.primary.fontFamily,
       fontWeight: 'inherit',
 
-      padding: 8,
-      fontSize: 14,
+      padding: 0,
       minWidth: 20,
       maxHeight: 50,
       borderWidth: 1,
@@ -63,6 +62,7 @@ export default theme => {
     },
     child: {
       display: 'block',
+      margin: 8,
       height: 'calc(100% - 16px)',
 
       '&::before': {

--- a/src/components/table/data.js
+++ b/src/components/table/data.js
@@ -1,4 +1,4 @@
-const data = [
+export const data = [
   ['HM B', 'Hennes & Mauritz AB, H & M ser. B', 10, 271, -0.48],
   ['ERIC B', 'Ericsson, Telefonab. L M ser. B', 10, 61.4, -0.73],
   ['BOL A', 'Boliden AB', 10, 192.1, -0.16],
@@ -13,4 +13,11 @@ const data = [
   ['TEL A', 'Telia Company AB', 10, 39.28, -0.58],
 ];
 
-module.exports = data;
+export const quarterlyData = [
+  ['14:20', 'dbx MSCI World Index UCITS ETF (DR)', 'Köp', 7, '459,90 SEK', '3 219,33 SEK', 'XDWD', 'XSTO'],
+  ['14:14', 'XACT Svenska Småbolag (UCITS ETF)', 'Köp', 2, '140,70 SEK', '281,40 SEK', 'XACT Smabolag', 'XSTO'],
+  ['14:14', 'IS C.MSCI EMIMI U.ETF DLA', 'Köp', 2, '24,37 EUR', '48,74 EUR', 'IS3N', 'XETRA'],
+  ['14:14', 'XACT Råvaror (UCITS ETF)', 'Köp', 2, '134,35 SEK', '268,70 SEK', 'XACT Ravaror', 'XSTO'],
+  ['14:12', 'XACT OMXS30', 'Köp', 1, '191,15 SEK', '191,15 SEK', 'XACT OMXS30', 'XSTO'],
+  ['10:46', 'CFS-DBXT MSCI WLD ETF 1C', 'Sälj', 6, '48,23 EUR', '289,38 EUR', 'XDWD', 'XETRA'],
+];

--- a/src/components/table/table.md
+++ b/src/components/table/table.md
@@ -6,7 +6,7 @@ Table with Sticky header and mobile mode using flex-basis, lots of rows to test 
     // component. This was needed to have a toggle button with state.
     const React = require('react');
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td, Icon } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
     const center = {justifyContent: 'center'};
 
     let tableData = [];
@@ -115,7 +115,7 @@ Table with Sticky header and mobile mode using flex-basis, lots of rows to test 
 Table with two sticky (one with stickyOffset).
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} size="md">
       <Thead borderBottom>
@@ -148,7 +148,7 @@ Table with two sticky (one with stickyOffset).
 Table with size md and sticky header in primary colors and borders:
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} size="md">
       <Thead variant="primary">
@@ -176,7 +176,7 @@ Table with size md and sticky header in primary colors and borders:
 Table with size xs and header in secondary colors and no borders:
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} size="xs">
       <Thead variant="secondary">
@@ -203,7 +203,7 @@ Table with size xs and header in secondary colors and no borders:
 Table with different sizes on Tbody, Thead and TFoot
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} size="sm">
       <Thead size="md">
@@ -238,7 +238,7 @@ Table with different sizes on Tbody, Thead and TFoot
 Table with size on Table level
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} size="xs">
       <Thead>
@@ -273,7 +273,7 @@ Table with size on Table level
 Table with max-height (scrollable)
 
     const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
-    const data = require('./data.js');
+    const { data } = require('./data.js');
 
     <Table minWidth={700} maxHeight={250}>
       <Thead>
@@ -303,3 +303,45 @@ Table with max-height (scrollable)
         </Tr>
       </Tfoot>
     </Table>
+
+
+Table with equal width columns and no ellipsis bound by a limited width parent
+
+    const { Table, Thead, Tbody, Tfoot, Th, Tr, Td } = require('../../'); // nordnet-ui-kit
+    const { quarterlyData } = require('./data.js');
+
+    const tableWrapperStyle = {
+      overflow: 'hidden',
+      width: 742,
+    };
+    
+    <div style={tableWrapperStyle}>
+      <Table tableLayoutAuto={true}>
+        <Thead>
+          <Tr sticky>
+            <Th ellipsis={false}>Tid</Th>
+            <Th ellipsis={false}>Namn</Th>
+            <Th ellipsis={false}>Ordertyp</Th>
+            <Th ellipsis={false}>Antal</Th>
+            <Th ellipsis={false} align="right">Kurs</Th>
+            <Th ellipsis={false} align="right">Belopp</Th>
+            <Th ellipsis={false}>Symbol</Th>
+            <Th ellipsis={false}>Marknadsplats</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          { quarterlyData.map(instrument => (
+            <Tr key={`${instrument[0]}${instrument[1]}`}>
+              <Td ellipsis={false}>{ instrument[0] }</Td>
+              <Td ellipsis={false}>{ instrument[1] }</Td>
+              <Td ellipsis={false}>{ instrument[2] }</Td>
+              <Td ellipsis={false}>{ instrument[3] }</Td>
+              <Td ellipsis={false} align="right">{ instrument[4] }</Td>
+              <Td ellipsis={false} align="right">{ instrument[5] }</Td>
+              <Td ellipsis={false}>{ instrument[6] }</Td>
+              <Td ellipsis={false}>{ instrument[7] }</Td>
+            </Tr>
+          )) }
+        </Tbody>
+      </Table>
+    </div>


### PR DESCRIPTION
Added an example and padding left/right. Without left/right padding the cells can touch eachother if there is too much content. There doesn't seem to be any issue with the left/right padding on the other examples.