### PR TITLE
fix(logo): hide nordnet text when onlyIcon is set

### DIFF
--- a/src/components/logo/logo.jsx
+++ b/src/components/logo/logo.jsx
@@ -9,6 +9,7 @@ function Logo({ onlyIcon, height, iconColor, textColor, ...rest }) {
     fill: iconColor,
     stroke: textColor,
     viewBox: onlyIcon ? '0 0 64 64' : undefined,
+    style: { overflow: 'hidden' },
     ...rest,
   };
 


### PR DESCRIPTION
the black nordnet text is always visisble in ie 11