### PR TITLE
fix: Fix render issue for small flags

### DIFF
--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -10,6 +10,8 @@ function Flag({ className, style, countryCode, secondaryCountryCode, size, round
       width: size,
       height: size * 0.75,
       marginLeft: round ? -size * 0.125 : null,
+      position: round ? 'absolute' : 'relative',
+      left: 0,
     },
     style,
   );


### PR DESCRIPTION
Use position absolute on round flags to position the svg correctly in the circle.

Previous: 
![screen shot 2018-05-28 at 16 17 42](https://user-images.githubusercontent.com/1640968/40618719-b12aaacc-6292-11e8-9303-f6134088f3b6.png)

With the fix:
![screen shot 2018-05-28 at 16 17 26](https://user-images.githubusercontent.com/1640968/40618732-b7897010-6292-11e8-8645-2d4f764cfbb4.png)
