### PR TITLE
fix too many dynamic stylesheets for table

### DIFF
--- a/src/components/thead/thead-styles.jsx
+++ b/src/components/thead/thead-styles.jsx
@@ -21,7 +21,7 @@ export default theme => {
     sticky: {
       '& th': {
         position: 'sticky',
-        top: props => props.stickyOffset || 0,
+        top: 'inherit',
         backgroundColor: color.white,
       },
     },

--- a/src/components/thead/thead-styles.jsx
+++ b/src/components/thead/thead-styles.jsx
@@ -1,7 +1,7 @@
 import styleUtils from '../table/style-utilities';
 import color from '../../styles/color';
 
-export default theme => {
+const normal = theme => {
   const { palette, mixins, typography } = theme;
 
   return {
@@ -21,7 +21,7 @@ export default theme => {
     sticky: {
       '& th': {
         position: 'sticky',
-        top: 'inherit',
+        top: 0,
         backgroundColor: color.white,
       },
     },
@@ -33,3 +33,14 @@ export default theme => {
     },
   };
 };
+
+const stickyOffset = theme => ({
+  ...normal(theme),
+  stickyOffset: {
+    '& th': {
+      top: props => props.stickyOffset,
+    },
+  },
+});
+
+export { normal as default, stickyOffset };

--- a/src/components/thead/thead.jsx
+++ b/src/components/thead/thead.jsx
@@ -12,6 +12,7 @@ function Thead({
   hiddenOnMobile,
   sticky,
   stickyBorder,
+  stickyOffset,
   theme, // eslint-disable-line react/prop-types
   sheet, // eslint-disable-line react/prop-types
   ...rest
@@ -27,8 +28,10 @@ function Thead({
     className,
   );
 
+  const style = { top: stickyOffset || 0 };
+
   return (
-    <thead {...rest} className={usedClassName}>
+    <thead {...rest} className={usedClassName} style={style}>
       {children}
     </thead>
   );
@@ -38,6 +41,7 @@ Thead.defaultProps = {
   hiddenOnMobile: false,
   sticky: false,
   stickyBorder: false,
+  stickyOffset: 0,
 };
 
 Thead.propTypes = {
@@ -49,6 +53,7 @@ Thead.propTypes = {
   hiddenOnMobile: PropTypes.bool,
   sticky: PropTypes.bool,
   stickyBorder: PropTypes.bool,
+  stickyOffset: PropTypes.number,
 };
 
 export default injectSheet(styles)(Thead);

--- a/src/components/thead/thead.jsx
+++ b/src/components/thead/thead.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import injectSheet from 'react-jss';
 import classNames from 'classnames';
-import styles from './thead-styles';
+import styles, { stickyOffset as stickyOffsetStyles } from './thead-styles';
 
 function Thead({
   classes,
@@ -25,13 +25,12 @@ function Thead({
       [classes.sticky]: sticky,
       [classes.stickyBorder]: stickyBorder,
     },
+    stickyOffset && { [classes.stickyOffset]: stickyOffset },
     className,
   );
 
-  const style = { top: stickyOffset || 0 };
-
   return (
-    <thead {...rest} className={usedClassName} style={style}>
+    <thead {...rest} className={usedClassName}>
       {children}
     </thead>
   );
@@ -56,4 +55,11 @@ Thead.propTypes = {
   stickyOffset: PropTypes.number,
 };
 
-export default injectSheet(styles)(Thead);
+const Normal = injectSheet(styles)(Thead);
+const Sticky = injectSheet(stickyOffsetStyles)(Thead);
+
+const Wrapper = props => (props.stickyOffset ? <Sticky {...props} /> : <Normal {...props} />);
+
+Wrapper.propTypes = { stickyOffset: Thead.propTypes.stickyOffset };
+
+export default Wrapper;

--- a/src/components/thead/thead.jsx
+++ b/src/components/thead/thead.jsx
@@ -24,8 +24,8 @@ function Thead({
       [classes.hiddenOnMobile]: hiddenOnMobile,
       [classes.sticky]: sticky,
       [classes.stickyBorder]: stickyBorder,
+      [classes.stickyOffset]: stickyOffset,
     },
-    stickyOffset && { [classes.stickyOffset]: stickyOffset },
     className,
   );
 

--- a/src/components/tr/tr-styles.jsx
+++ b/src/components/tr/tr-styles.jsx
@@ -1,8 +1,8 @@
 import styleUtils from '../table/style-utilities';
 import color from '../../styles/color';
 
-export default theme => {
-  const { mixins, palette } = theme;
+const normal = theme => {
+  const { mixins } = theme;
 
   return {
     tr: {
@@ -27,15 +27,26 @@ export default theme => {
     sticky: {
       '& td': {
         position: 'sticky',
-        top: 'inherit',
+        top: 0,
         backgroundColor: color.white,
       },
     },
     stickyBorder: {
       '& td': {
         border: 0,
-        background: `linear-gradient(to top, ${palette.shades.dark.text.muted} 2px, ${color.white} 2px)`,
+        background: `linear-gradient(to top, ${theme.palette.shades.dark.text.muted} 2px, ${color.white} 2px)`,
       },
     },
   };
 };
+
+const stickyOffset = theme => ({
+  ...normal(theme),
+  stickyOffset: {
+    '& td': {
+      top: props => props.stickyOffset,
+    },
+  },
+});
+
+export { normal as default, stickyOffset };

--- a/src/components/tr/tr-styles.jsx
+++ b/src/components/tr/tr-styles.jsx
@@ -27,7 +27,7 @@ export default theme => {
     sticky: {
       '& td': {
         position: 'sticky',
-        top: props => props.stickyOffset || 0,
+        top: 'inherit',
         backgroundColor: color.white,
       },
     },

--- a/src/components/tr/tr.jsx
+++ b/src/components/tr/tr.jsx
@@ -16,8 +16,11 @@ function Tr({ classes, className, children, size, border, sticky, stickyBorder, 
     },
     className,
   );
+
+  const style = { top: stickyOffset || 0 };
+
   return (
-    <tr {...omit(rest, 'theme', 'sheet')} className={usedClassName}>
+    <tr {...omit(rest, 'theme', 'sheet')} className={usedClassName} style={style}>
       {children}
     </tr>
   );

--- a/src/components/tr/tr.jsx
+++ b/src/components/tr/tr.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import injectSheet from 'react-jss';
 import classNames from 'classnames';
 import omit from '../../utilities/omit';
-import styles from './tr-styles';
+import styles, { stickyOffset as stickyOffsetStyles } from './tr-styles';
 
 function Tr({ classes, className, children, size, border, sticky, stickyBorder, stickyOffset, ...rest }) {
   const usedClassName = classNames(
@@ -14,13 +14,12 @@ function Tr({ classes, className, children, size, border, sticky, stickyBorder, 
       [classes.sticky]: sticky,
       [classes.stickyBorder]: stickyBorder,
     },
+    stickyOffset && { [classes.stickyOffset]: stickyOffset }, // classNames will filter out this if false
     className,
   );
 
-  const style = { top: stickyOffset || 0 };
-
   return (
-    <tr {...omit(rest, 'theme', 'sheet')} className={usedClassName} style={style}>
+    <tr {...omit(rest, 'theme', 'sheet')} className={usedClassName}>
       {children}
     </tr>
   );
@@ -45,4 +44,9 @@ Tr.propTypes = {
   stickyOffset: PropTypes.number,
 };
 
-export default injectSheet(styles)(Tr);
+const Normal = injectSheet(styles)(Tr);
+const Sticky = injectSheet(stickyOffsetStyles)(Tr);
+
+const Wrapper = props => (props.stickyOffset ? <Sticky {...props} /> : <Normal {...props} />);
+
+Wrapper.propTypes = { stickyOffset: Tr.propTypes.stickyOffset };

--- a/src/components/tr/tr.jsx
+++ b/src/components/tr/tr.jsx
@@ -13,8 +13,8 @@ function Tr({ classes, className, children, size, border, sticky, stickyBorder, 
       [classes.border]: border,
       [classes.sticky]: sticky,
       [classes.stickyBorder]: stickyBorder,
+      [classes.stickyOffset]: stickyOffset,
     },
-    stickyOffset && { [classes.stickyOffset]: stickyOffset }, // classNames will filter out this if false
     className,
   );
 

--- a/src/components/tr/tr.jsx
+++ b/src/components/tr/tr.jsx
@@ -50,3 +50,5 @@ const Sticky = injectSheet(stickyOffsetStyles)(Tr);
 const Wrapper = props => (props.stickyOffset ? <Sticky {...props} /> : <Normal {...props} />);
 
 Wrapper.propTypes = { stickyOffset: Tr.propTypes.stickyOffset };
+
+export default Wrapper;


### PR DESCRIPTION
Doesn't break the api, nor any functionality. I simply wrap the `Tr` and `Thead` components in a component that injects dynamic stylesheets only when needed (when `stickyOffset` is used, which it hardly is, but that's different problem). 

Tested in modern browsers and works as before. It works just as before in IE as well, the problem is that `sticky` is not [supported](https://caniuse.com/#feat=css-sticky) in IE so it has never worked there.

Perhaps the most important of all the stylesheet fixes. Will dramatically improve performance as we use tables so frequently. 