### PR TITLE
Feat/tooltip desktop only

### DIFF
--- a/src/components/tooltip/tooltip-styles.jsx
+++ b/src/components/tooltip/tooltip-styles.jsx
@@ -53,6 +53,21 @@ export default theme => {
       },
     },
 
+    desktopOnlyWrapper: {
+      display: 'inline-block',
+    },
+    desktopOnly: {
+      display: 'none',
+      [mixins.media('md')]: {
+        display: 'inline-block',
+      },
+    },
+    mobileOnly: {
+      [mixins.media('md')]: {
+        display: 'none',
+      },
+    },
+
     popup: {
       transition: transitions.create(['opacity']),
       position: 'absolute',

--- a/src/components/tooltip/tooltip-styles.jsx
+++ b/src/components/tooltip/tooltip-styles.jsx
@@ -53,21 +53,6 @@ export default theme => {
       },
     },
 
-    desktopOnlyWrapper: {
-      display: 'inline-block',
-    },
-    desktopOnly: {
-      display: 'none',
-      [mixins.media('md')]: {
-        display: 'inline-block',
-      },
-    },
-    mobileOnly: {
-      [mixins.media('md')]: {
-        display: 'none',
-      },
-    },
-
     popup: {
       transition: transitions.create(['opacity']),
       position: 'absolute',
@@ -164,6 +149,12 @@ export default theme => {
       overflowWrap: 'break-word',
       wordBreak: 'break-word',
       wordWrap: 'break-word',
+    },
+    popupDesktopOnly: {
+      display: 'none',
+      [mixins.media('md')]: {
+        display: 'block',
+      },
     },
   };
 };

--- a/src/components/tooltip/tooltip-styles.jsx
+++ b/src/components/tooltip/tooltip-styles.jsx
@@ -151,9 +151,8 @@ export default theme => {
       wordWrap: 'break-word',
     },
     popupDesktopOnly: {
-      display: 'none',
-      [mixins.media('md')]: {
-        display: 'block',
+      [mixins.maxMedia('md')]: {
+        display: 'none',
       },
     },
   };

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -218,5 +218,18 @@ Tooltip.propTypes = {
   fixedWidth: PropTypes.number, //  eslint-disable-line
 };
 
+/* eslint-disable react/prop-types */
+const DesktopOnlyTooltipWrapper = props => {
+  if (!props.desktopOnly) return <Tooltip {...props} />;
+  const { classes, className, children } = props;
+  return (
+    <div className={classes.desktopOnlyWrapper}>
+      <Tooltip className={classnames(classes.desktopOnly, className)} {...props} />
+      <div className={classes.mobileOnly}>{children}</div>
+    </div>
+  );
+};
+/* eslint-enable react/prop-types */
+
 export { Tooltip as Component, styles };
-export default injectSheet(styles)(Tooltip);
+export default injectSheet(styles)(DesktopOnlyTooltipWrapper);

--- a/src/components/tooltip/tooltip.jsx
+++ b/src/components/tooltip/tooltip.jsx
@@ -132,7 +132,7 @@ class Tooltip extends Component {
       }
     }
 
-    const { fixedWidth } = this.props;
+    const { fixedWidth, desktopOnly } = this.props;
     const { hover, toggled } = this.state;
 
     const wrapperStyle = {
@@ -142,16 +142,19 @@ class Tooltip extends Component {
       ...tooltipStyle,
     };
 
+    const classes = this.classes;
+    const wrapperClasses = classnames(classes.popup, classes[placement], {
+      [classes.popupFixed]: fixedWidth,
+      [classes.popupDesktopOnly]: desktopOnly,
+    });
+
     const contentStyle = {
       left: this.left,
       position: (placement === 'above' || placement === 'below') && fixedWidth ? 'absolute' : 'static',
       bottom: placement === 'above' ? 0 : 'auto',
     };
-
-    const classes = this.classes;
-
     return (
-      <div className={classnames(classes.popup, classes[placement], fixedWidth && classes.popupFixed)} style={wrapperStyle}>
+      <div className={wrapperClasses} style={wrapperStyle}>
         <div
           style={contentStyle}
           className={classnames(classes.popupContent, classes[placement], fixedWidth && classes.popupContentFixed)}
@@ -200,6 +203,7 @@ Tooltip.defaultProps = {
   children: <Questionmark width={16} height={16} />,
   placement: 'below',
   sticky: true,
+  desktopOnly: false,
 };
 
 Tooltip.propTypes = {
@@ -216,20 +220,8 @@ Tooltip.propTypes = {
   sticky: PropTypes.bool,
   placement: PropTypes.oneOf(['above', 'below', 'right', 'left']),
   fixedWidth: PropTypes.number, //  eslint-disable-line
+  desktopOnly: PropTypes.bool,
 };
-
-/* eslint-disable react/prop-types */
-const DesktopOnlyTooltipWrapper = props => {
-  if (!props.desktopOnly) return <Tooltip {...props} />;
-  const { classes, className, children } = props;
-  return (
-    <div className={classes.desktopOnlyWrapper}>
-      <Tooltip className={classnames(classes.desktopOnly, className)} {...props} />
-      <div className={classes.mobileOnly}>{children}</div>
-    </div>
-  );
-};
-/* eslint-enable react/prop-types */
 
 export { Tooltip as Component, styles };
-export default injectSheet(styles)(DesktopOnlyTooltipWrapper);
+export default injectSheet(styles)(Tooltip);

--- a/src/components/tooltip/tooltip.md
+++ b/src/components/tooltip/tooltip.md
@@ -1,4 +1,4 @@
-    const { Icon } = require('../../'); // nordnet-ui-kit
+    const { Icon, Button } = require('../../'); // nordnet-ui-kit
 
     <ul>
       <li style={{marginBottom: '11px'}}>
@@ -72,6 +72,13 @@
         <span>How it looks when using another icon:</span>
         <Tooltip content={ <span>A heart</span> }>
           <Icon.Heart fill="tomato" stroke="tomato" width={ 16 } height={ 16 } />
+        </Tooltip>
+      </li>
+
+      <li style={{marginBottom: '11px'}}>
+        <span>How it looks when it's desktop only: </span>
+        <Tooltip content={ <span>I'm only visible on desktop</span> } desktopOnly placement="above">
+          <Button variant="primary" modifier="action">Click me!</Button>
         </Tooltip>
       </li>
 

--- a/test/components/tooltip/tooltip.test.js
+++ b/test/components/tooltip/tooltip.test.js
@@ -70,6 +70,12 @@ describe('<Tooltip />', () => {
     expect(wrapper.find(`.${classes.popup}`).hasClass('below')).to.equal(true);
   });
 
+  it('should set desktopOnly', () => {
+    wrapper = shallow(<Tooltip classes={classes} content="Lorem ipsum dolor sit amet." desktopOnly />);
+    wrapper.find(`.${classes.container}`).simulate('mouseEnter');
+    expect(wrapper.find(`.${classes.popup}`).hasClass(classes.popupDesktopOnly)).to.equal(true);
+  });
+
   describe('click outside functionality', () => {
     const target = { attachTo: document.getElementById('app') };
     let component;


### PR DESCRIPTION
A prop to display the tooltip popup only on desktop. A more complicated implementation is already used internally to achieve this functionality. 