### PR TITLE
fix(editable-input): adjust size of edit button and fix ie/edge bugs

### DIFF
--- a/src/components/editable-input/editable-input-styles.jsx
+++ b/src/components/editable-input/editable-input-styles.jsx
@@ -35,10 +35,10 @@ export default theme => ({
   buttons: {
     display: 'flex',
     flexDirection: 'row',
+    flexShrink: 0,
   },
   buttonEdit: {
-    width: 24,
-    height: 24,
-    marginTop: 9,
+    width: 31,
+    height: 31,
   },
 });

--- a/src/components/editable-input/editable-input.jsx
+++ b/src/components/editable-input/editable-input.jsx
@@ -28,6 +28,12 @@ class EditableInput extends React.Component {
   };
 
   onFocus = event => {
+    /* NOTE: Workaround for moving cursor to end of input in IE/Edge */
+    const value = event.target.value;
+    const target = event.target;
+    target.value = '';
+    target.value = value;
+
     if (this.props.onFocus) {
       this.props.onFocus(event);
     }


### PR DESCRIPTION
Buttons where getting squished together on IE/Edge and the cursor was not moving to the end of the input on focus.

I also adjusted the size of the Edit button to be the same height as the Submit/Cancel buttons.