### PR TITLE
fix: add z-index to table head cells

### DIFF
--- a/src/components/thead/thead-styles.jsx
+++ b/src/components/thead/thead-styles.jsx
@@ -22,6 +22,7 @@ const normal = theme => {
       '& th': {
         position: 'sticky',
         top: 0,
+        zIndex: 1,
         backgroundColor: color.white,
       },
     },


### PR DESCRIPTION
add z-index to table head cells to solve sticky table head problem when scrolling