### PR TITLE
feat(button): support icon above the text

### DIFF
--- a/src/components/button/button-styles.jsx
+++ b/src/components/button/button-styles.jsx
@@ -188,6 +188,10 @@ export default theme => {
       borderRadius: '50%',
     },
 
+    iconAbove: {
+      flexDirection: 'column',
+    },
+
     iconText: {},
 
     innerWrapper: {

--- a/src/components/button/button.jsx
+++ b/src/components/button/button.jsx
@@ -23,6 +23,7 @@ function Button({
   node,
   href,
   icon,
+  iconAbove,
   size,
   theme, // eslint-disable-line react/prop-types
   sheet, // eslint-disable-line react/prop-types
@@ -54,12 +55,15 @@ function Button({
     size,
     className,
   );
+  const innerButtonWrapper = classNames(classes.innerWrapper, {
+    [classes.iconAbove]: iconAbove,
+  });
 
   return (
     <Element {...rest} className={usedClassName} disabled={disabled} href={href}>
-      <div className={classes.innerWrapper}>
+      <div className={innerButtonWrapper}>
         {icon}
-        <span className={classNames({ [classes.spaceForIcon]: icon && children })}>{children}</span>
+        <span className={classNames({ [classes.spaceForIcon]: icon && children && !iconAbove })}>{children}</span>
       </div>
     </Element>
   );
@@ -83,6 +87,7 @@ Button.propTypes = {
   size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
   href: PropTypes.string,
   icon: PropTypes.node,
+  iconAbove: PropTypes.bool,
   disabled: PropTypes.bool,
 };
 


### PR DESCRIPTION
Icons currently are only supported to the left of text. This adds support to add an icon above text. Matches the behavior of the modal:

![screen shot 2018-07-19 at 11 38 16](https://user-images.githubusercontent.com/235857/42934773-412cb236-8b48-11e8-92bb-c639790b8aad.png)



Example:

![screen shot 2018-07-19 at 11 32 42](https://user-images.githubusercontent.com/235857/42934737-2457510c-8b48-11e8-8516-ddb185a5a14b.png)
