### PR TITLE
feat(Input): add optgroup support for input type=select

### DIFF
--- a/src/components/input/input-select.jsx
+++ b/src/components/input/input-select.jsx
@@ -10,9 +10,18 @@ import styles from './input-select-styles';
 import omit from '../../utilities/omit';
 
 function renderOption(option) {
-  const { label, value, key: keyOption, ...rest } = option;
-  const key = keyOption || kebabCase(value); // Assumes value is a string
+  const { label, value, key: keyOption, options, ...rest } = option;
 
+  if (options) {
+    const key = keyOption || kebabCase(label); // Assumes optgroup label is unique
+    return (
+      <optgroup {...rest} key={key} label={label}>
+        {options.map(renderOption)}
+      </optgroup>
+    );
+  }
+
+  const key = keyOption || kebabCase(value); // Assumes value is a string
   return (
     <option {...rest} key={key} value={value}>
       {label}
@@ -54,7 +63,9 @@ class InputSelect extends InputDefault.InnerComponent {
   }
 
   getSelectedOption() {
-    return this.props.options.find(opt => `${opt.value}` === this.state.value);
+    return this.props.options
+      .reduce((prev, opt) => [...prev, ...(opt.options ? opt.options : [opt])], [])
+      .find(opt => `${opt.value}` === this.state.value);
   }
 
   getTitle() {
@@ -122,7 +133,14 @@ InputSelect.propTypes = {
     PropTypes.shape({
       label: PropTypes.string.isRequired,
       key: PropTypes.string,
-      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]).isRequired,
+      value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]),
+      options: PropTypes.arrayOf(
+        PropTypes.shape({
+          label: PropTypes.string.isRequired,
+          key: PropTypes.string,
+          value: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.object]).isRequired,
+        }),
+      ),
     }),
   ),
   variant: PropTypes.oneOf(['primary', 'secondary']),

--- a/src/components/input/input.md
+++ b/src/components/input/input.md
@@ -132,6 +132,29 @@ Type: `select`
       label: 'Super mega very long option 3 - this is a test to show that the option is properly cut after a specific length and that the whole option text is shown in a title tag',
       value: 3,
     }];
+
+    const optgroupOptions = [{
+      label: 'Optgroup 1',
+      options: [{
+        label: 'Option 1',
+        value: 1,
+      }, {
+        label: 'Option 2',
+        value: 2,
+      }],
+    }, {
+      label: 'Option 3',
+      value: 3,
+    }, {
+      label: 'Optgroup 2',
+      options: [],
+    }, {
+      label: 'Optgroup 3',
+      options: [{
+        label: 'Option 4',
+        value: 4,
+      }],
+    }];
     <div>
       <Input
         label="Select input"
@@ -189,6 +212,14 @@ Type: `select`
         selectablePlaceholder
         type="select"
         options={ options }
+        hasSuccess
+        variant="secondary"
+      />
+      <Input
+        label="Select input with optgroups"
+        placeholder="Pick option"
+        type="select"
+        options={ optgroupOptions }
         hasSuccess
         variant="secondary"
       />


### PR DESCRIPTION
Add support for opgroups in <Input type="select"/> by letting option objects have options themselves.

![image](https://user-images.githubusercontent.com/5429582/44784963-a0212580-ab8f-11e8-9466-5f707940f397.png)
