### PR TITLE
fix: remove state from pagination

### DIFF
--- a/src/components/pagination/pagination.jsx
+++ b/src/components/pagination/pagination.jsx
@@ -7,20 +7,6 @@ import Range from './range';
 import styles from './pagination-styles';
 
 class Pagination extends Component {
-  static getDerivedStateFromProps(props, state) {
-    const selectedFromParent = parseInt(props.selected, 10);
-    if (selectedFromParent !== state.selected) {
-      // Parent component forcing a reset/change of selected page
-      return { selected: selectedFromParent };
-    }
-
-    return null;
-  }
-
-  state = {
-    selected: parseInt(this.props.selected, 10),
-  };
-
   calcPagesCount() {
     const { total, limit } = this.props;
 
@@ -28,15 +14,14 @@ class Pagination extends Component {
   }
 
   handlePreviousPage = () => {
-    const { selected } = this.state;
-
+    const { selected } = this.props;
     if (selected > 1) {
       this.handlePageSelected(selected - 1);
     }
   };
 
   handleNextPage = () => {
-    const { selected } = this.state;
+    const { selected } = this.props;
     const pagesCount = this.calcPagesCount();
 
     if (selected < pagesCount) {
@@ -46,10 +31,6 @@ class Pagination extends Component {
 
   handlePageSelected = number => {
     const { changeHandler } = this.props;
-    this.setState({
-      selected: number,
-    });
-
     changeHandler(number);
   };
 
@@ -63,8 +44,8 @@ class Pagination extends Component {
       anchors,
       pageLabelText,
       pageLabelTextSelected,
+      selected,
     } = this.props;
-    const { selected } = this.state;
 
     const pagesCount = this.calcPagesCount();
 
@@ -100,6 +81,7 @@ Pagination.propTypes = {
   classes: PropTypes.object.isRequired,
   total: PropTypes.number.isRequired,
   limit: PropTypes.number,
+  /** Callback that returns the page chosen */
   changeHandler: PropTypes.func,
   /** Screenreader friendly title for the pagination */
   title: PropTypes.string,

--- a/src/components/pagination/pagination.md
+++ b/src/components/pagination/pagination.md
@@ -1,7 +1,26 @@
+    // This is a sample component to enable testing setting value from outside the UI-Kit
+    const React = require('react');
+
+    class PaginationExample extends React.PureComponent {
+      constructor(props) {
+        super(props);
+        this.state = { selected: 1 };
+      }
+
+      render() {
+        return (
+          <div>
+            <Pagination selected={this.state.selected} total={50} changeHandler={(pageNumber) => this.setState({ selected: pageNumber }) } />
+          </div>);
+      }
+    }
+
+    <PaginationExample />
+
 Simple, few pages (default):
 
     <div>
-      <Pagination selected={1} total={50} changeHandler={() => {}} />
+      <Pagination total={100} changeHandler={() => {}} />
     </div>
 
 Advanced:

--- a/test/components/pagination/pagination.test.js
+++ b/test/components/pagination/pagination.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { expect } from 'chai';
 import { shallow } from 'enzyme';
-import sinon from 'sinon';
 import { mockClasses, Icon } from '../../../src';
 import { Component as Pagination, styles } from '../../../src/components/pagination/pagination';
 import Stepper from '../../../src/components/pagination/stepper';
@@ -132,31 +131,5 @@ describe('<Pagination />', () => {
     const wrapper = shallowComponent();
 
     expect(wrapper.find(Range).length).to.equal(1);
-  });
-
-  it('should increment selected in state', () => {
-    const clickCallback = sinon.spy();
-    const wrapper = shallowComponent({ changeHandler: clickCallback });
-
-    wrapper
-      .find(Stepper)
-      .last()
-      .props()
-      .clickHandler();
-
-    expect(wrapper.state().selected).to.equal(2);
-  });
-
-  it('should decrement selected in state', () => {
-    const clickCallback = sinon.spy();
-    const wrapper = shallowComponent({ changeHandler: clickCallback, selected: 2 });
-
-    wrapper
-      .find(Stepper)
-      .first()
-      .props()
-      .clickHandler();
-
-    expect(wrapper.state().selected).to.equal(1);
   });
 });


### PR DESCRIPTION
Example broke when props always override state, so setState didnt work any more.
removed internal state and just use incoming prop for selected

added new example to set page from outside component.

https://reactjs.org/blog/2018/06/07/you-probably-dont-need-derived-state.html