### PR TITLE
fix(Flag): fix so that flag inherits styles passed as props

### DIFF
--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -7,16 +7,20 @@ import CurrencyFlag from './flags/currencies';
 
 export const styles = theme => {
   const { palette } = theme;
-
+  const addBorder = props => !props.hideBorder && !props.round && !props.secondaryCountryCode;
   return {
+    container: {
+      lineHeight: 0,
+    },
     flagStyle: {
       display: 'inline-block',
       width: props => props.size,
-      height: props => props.size * 0.75,
+      height: props => (addBorder(props) ? 'auto' : props.size * 0.75),
       marginLeft: props => (props.round ? -props.size * 0.125 : null),
       position: props => (props.round ? 'absolute' : 'relative'),
+      boxSizing: 'border-box',
       left: 0,
-      outline: props => (!props.round && !props.secondaryCountryCode ? `1px solid ${palette.color.grayLighter}` : null),
+      border: props => (addBorder(props) ? `1px solid ${props.borderColor || palette.color.grayLightest}` : null),
     },
     roundFlagStyle: {
       display: 'inline-block',
@@ -29,11 +33,12 @@ export const styles = theme => {
   };
 };
 
-const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, size, round, ...rest }) => {
+const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, size, round, hideBorder, borderColor, ...rest }) => {
   if (secondaryCountryCode) {
     return (
       <CurrencyFlag
         className={cn(classes.flagStyle, className, 'flag')}
+        style={style}
         size={size}
         primaryCC={countryCode.toLowerCase()}
         secondaryCC={secondaryCountryCode.toLowerCase()}
@@ -46,7 +51,11 @@ const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, si
     return null;
   }
 
-  const flag = <SvgFlag className={cn(classes.flagStyle, className, 'flag')} {...rest} />;
+  const flag = (
+    <div className={classes.container}>
+      <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...rest} />
+    </div>
+  );
 
   if (round) {
     return <span className={classes.roundFlagStyle}>{flag}</span>;
@@ -59,6 +68,8 @@ Flag.defaultProps = {
   countryCode: '',
   size: 32,
   round: false,
+  hideBorder: false,
+  borderColor: '',
 };
 
 const countryCodes = [
@@ -100,6 +111,8 @@ Flag.propTypes = {
   size: PropTypes.number,
   style: PropTypes.object,
   round: PropTypes.bool,
+  hideBorder: PropTypes.bool,
+  borderColor: PropTypes.string,
 };
 export { Flag as Component };
 export default injectSheet(styles)(Flag);

--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -4,25 +4,27 @@ import injectSheet from 'react-jss';
 import cn from 'classnames';
 import flags from './flags';
 import CurrencyFlag from './flags/currencies';
+import omit from '../../utilities/omit';
+
+const addBorder = props => !props.hideBorder && !props.round && !props.secondaryCountryCode;
 
 export const styles = theme => {
   const { palette } = theme;
-  const addBorder = props => !props.hideBorder && !props.round && !props.secondaryCountryCode;
   return {
     container: {
-      lineHeight: 0,
+      display: 'inline-block',
     },
     flagStyle: {
-      display: 'inline-block',
+      display: 'block',
       width: props => props.size,
-      height: props => (addBorder(props) ? 'auto' : props.size * 0.75),
+      height: props => (addBorder(props) ? (props.size - 2) * 0.75 + 2 : props.size * 0.75),
       marginLeft: props => (props.round ? -props.size * 0.125 : null),
       position: props => (props.round ? 'absolute' : 'relative'),
       boxSizing: 'border-box',
       left: 0,
       border: props => (addBorder(props) ? `1px solid ${props.borderColor || palette.color.grayLightest}` : null),
     },
-    roundFlagStyle: {
+    roundFlagContainer: {
       display: 'inline-block',
       position: 'relative',
       width: props => props.size * 0.75,
@@ -51,17 +53,13 @@ const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, si
     return null;
   }
 
-  const flag = (
-    <div className={classes.container}>
-      <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...rest} />
-    </div>
-  );
+  const flag = <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...omit(rest, 'theme')} />;
 
   if (round) {
-    return <span className={classes.roundFlagStyle}>{flag}</span>;
+    return <span className={classes.roundFlagContainer}>{flag}</span>;
   }
 
-  return flag;
+  return <div className={classes.container}>{flag}</div>;
 };
 
 Flag.defaultProps = {

--- a/test/components/flag/flag.test.js
+++ b/test/components/flag/flag.test.js
@@ -16,10 +16,10 @@ describe('<Flag />', () => {
 
   it(`should be able to style size`, () => {
     expect(themedRealStyle.flagStyle.width({ size: 50 })).to.equal(50);
-    expect(themedRealStyle.flagStyle.height({ size: 50 })).to.equal('auto');
+    expect(themedRealStyle.flagStyle.height({ size: 50 })).to.equal(38);
 
-    expect(themedRealStyle.roundFlagStyle.width({ size: 50 })).to.equal(50 * 0.75);
-    expect(themedRealStyle.roundFlagStyle.height({ size: 50 })).to.equal(50 * 0.75);
+    expect(themedRealStyle.roundFlagContainer.width({ size: 50 })).to.equal(50 * 0.75);
+    expect(themedRealStyle.roundFlagContainer.height({ size: 50 })).to.equal(50 * 0.75);
   });
 
   it('should have the class "flag"', () => {
@@ -32,7 +32,7 @@ describe('<Flag />', () => {
 
   it('should add roundClass if round prop provided', () => {
     const newElement = shallow(<Flag countryCode="se" classes={classes} round />);
-    expect(newElement.hasClass('roundFlagStyle')).to.equal(true);
+    expect(newElement.hasClass('roundFlagContainer')).to.equal(true);
   });
 
   it('should be possible to show combined flag for currencies', () => {

--- a/test/components/flag/flag.test.js
+++ b/test/components/flag/flag.test.js
@@ -16,16 +16,18 @@ describe('<Flag />', () => {
 
   it(`should be able to style size`, () => {
     expect(themedRealStyle.flagStyle.width({ size: 50 })).to.equal(50);
-    expect(themedRealStyle.flagStyle.height({ size: 50 })).to.equal(50 * 0.75);
+    expect(themedRealStyle.flagStyle.height({ size: 50 })).to.equal('auto');
 
     expect(themedRealStyle.roundFlagStyle.width({ size: 50 })).to.equal(50 * 0.75);
     expect(themedRealStyle.roundFlagStyle.height({ size: 50 })).to.equal(50 * 0.75);
   });
 
   it('should have the class "flag"', () => {
-    expect(wrapper.hasClass('flag')).to.equal(true);
-    expect(wrapper.hasClass('flagStyle')).to.equal(true);
-    expect(wrapper.hasClass('roundFlagStyle')).to.equal(false);
+    const flagComponent = wrapper.children().first();
+    expect(wrapper.hasClass('container')).to.equal(true);
+    expect(flagComponent.hasClass('flag')).to.equal(true);
+    expect(flagComponent.hasClass('flagStyle')).to.equal(true);
+    expect(flagComponent.hasClass('roundFlagStyle')).to.equal(false);
   });
 
   it('should add roundClass if round prop provided', () => {


### PR DESCRIPTION
Fixed some QA comments:

* positioning is off in the search and in the market performance widget
* not enough space to display the borders of the flag on page watchlist and on page account details