### PR TITLE
fix(EditableInput): Wrap submit/cancel-buttons on mobile

### DIFF
--- a/src/components/editable-input/editable-input-styles.jsx
+++ b/src/components/editable-input/editable-input-styles.jsx
@@ -2,9 +2,13 @@ export default theme => ({
   container: {
     ...theme.typography.primary,
     display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-end',
+  },
+  isEditing: {
+    flexWrap: 'wrap',
+    [theme.mixins.media('md')]: {
+      flexWrap: 'nowrap',
+    },
   },
   form: {
     width: '100%',
@@ -34,11 +38,12 @@ export default theme => ({
   },
   buttons: {
     display: 'flex',
-    flexDirection: 'row',
     flexShrink: 0,
+    alignSelf: 'center',
   },
   buttonEdit: {
     width: 31,
     height: 31,
+    alignSelf: 'center',
   },
 });

--- a/src/components/editable-input/editable-input.jsx
+++ b/src/components/editable-input/editable-input.jsx
@@ -150,7 +150,7 @@ class EditableInput extends React.Component {
     );
 
     return (
-      <div className={classNames(classes.container, this.props.className)}>
+      <div className={classNames(classes.container, { [classes.isEditing]: this.state.editing }, this.props.className)}>
         {input}
         {buttons}
       </div>


### PR DESCRIPTION
From: 
![screen shot 2018-10-30 at 12 43 03](https://user-images.githubusercontent.com/1615161/47715902-6fb64000-dc41-11e8-871e-f2259ebcf5a2.png)

To: 
![screen shot 2018-10-30 at 12 43 20](https://user-images.githubusercontent.com/1615161/47715925-8066b600-dc41-11e8-9bf4-844fc1fc2fee.png)

