### PR TITLE
Flag performance improvement

### DIFF
--- a/src/components/flag/flag-deprecated.jsx
+++ b/src/components/flag/flag-deprecated.jsx
@@ -54,7 +54,9 @@ const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, si
     return null;
   }
 
-  const flag = <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...omit(rest, 'theme')} />;
+  const flag = (
+    <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...omit(rest, 'theme', 'round', 'countryCode')} />
+  );
 
   if (round) {
     return <span className={classes.roundFlagContainer}>{flag}</span>;

--- a/src/components/flag/flag-deprecated.jsx
+++ b/src/components/flag/flag-deprecated.jsx
@@ -1,0 +1,117 @@
+/** Will be deprecated. This component will be removed in next major release */
+import PropTypes from 'prop-types';
+import React from 'react';
+import injectSheet from 'react-jss';
+import cn from 'classnames';
+import flags from './flags';
+import CurrencyFlag from './flags/currencies';
+import omit from '../../utilities/omit';
+
+const addBorder = props => !props.hideBorder && !props.round && !props.secondaryCountryCode;
+
+export const styles = theme => {
+  const { palette } = theme;
+  return {
+    container: {
+      display: 'inline-block',
+    },
+    flagStyle: {
+      display: 'block',
+      width: props => props.size,
+      height: props => (addBorder(props) ? (props.size - 2) * 0.75 + 2 : props.size * 0.75),
+      marginLeft: props => (props.round ? -props.size * 0.125 : null),
+      position: props => (props.round ? 'absolute' : 'relative'),
+      boxSizing: 'border-box',
+      left: 0,
+      border: props => (addBorder(props) ? `1px solid ${props.borderColor || palette.color.grayLightest}` : null),
+    },
+    roundFlagContainer: {
+      display: 'inline-block',
+      position: 'relative',
+      width: props => props.size * 0.75,
+      height: props => props.size * 0.75,
+      overflow: 'hidden',
+      borderRadius: '50%',
+    },
+  };
+};
+
+const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, size, round, hideBorder, borderColor, ...rest }) => {
+  if (secondaryCountryCode) {
+    return (
+      <CurrencyFlag
+        className={cn(classes.flagStyle, className, 'flag')}
+        style={style}
+        size={size}
+        primaryCC={countryCode.toLowerCase()}
+        secondaryCC={secondaryCountryCode.toLowerCase()}
+      />
+    );
+  }
+  const SvgFlag = flags[countryCode.toLowerCase()];
+
+  if (!SvgFlag) {
+    return null;
+  }
+
+  const flag = <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...omit(rest, 'theme')} />;
+
+  if (round) {
+    return <span className={classes.roundFlagContainer}>{flag}</span>;
+  }
+
+  return <div className={classes.container}>{flag}</div>;
+};
+
+Flag.defaultProps = {
+  countryCode: '',
+  size: 32,
+  round: false,
+  hideBorder: false,
+  borderColor: '',
+};
+
+const countryCodes = [
+  'ca',
+  'de',
+  'fr',
+  'ru',
+  'gb',
+  'dk',
+  'fi',
+  'no',
+  'se',
+  'us',
+  'jp',
+  'cn',
+  'eu',
+  'CA',
+  'DE',
+  'FR',
+  'RU',
+  'GB',
+  'DK',
+  'FI',
+  'NO',
+  'SE',
+  'US',
+  'JP',
+  'CN',
+  'EU',
+];
+
+Flag.propTypes = {
+  classes: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  /** A valid 2-character country code */
+  countryCode: PropTypes.oneOf(countryCodes),
+  secondaryCountryCode: PropTypes.oneOf(countryCodes),
+  /** Unitless pixel value */
+  size: PropTypes.number,
+  style: PropTypes.object,
+  round: PropTypes.bool,
+  hideBorder: PropTypes.bool,
+  borderColor: PropTypes.string,
+};
+export { Flag as Component };
+export default injectSheet(styles)(Flag);

--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -80,7 +80,7 @@ Flag.propTypes = {
   secondaryCountryCode: PropTypes.oneOf(countryCodes),
   size: PropTypes.oneOfType([
     /** Unitless pixel value */
-    /** Will be deprecated. Size will be predefined and one of 'xs', 'sm', 'md', 'lg'. */
+    /** Will be deprecated. Size will not be a numerical value and will be predefined with value one of 'xs', 'sm', 'md', 'lg'. */
     PropTypes.number,
     PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
   ]),

--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -1,65 +1,38 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import injectSheet from 'react-jss';
-import cn from 'classnames';
-import flags from './flags';
-import CurrencyFlag from './flags/currencies';
+import { SvgFlag, CurrencyFlag } from './flags';
 import omit from '../../utilities/omit';
+import FlagDeprecated from './flag-deprecated';
+import color from '../../styles/color';
 
 const addBorder = props => !props.hideBorder && !props.round && !props.secondaryCountryCode;
 
-export const styles = theme => {
-  const { palette } = theme;
-  return {
-    container: {
-      display: 'inline-block',
-    },
-    flagStyle: {
-      display: 'block',
-      width: props => props.size,
-      height: props => (addBorder(props) ? (props.size - 2) * 0.75 + 2 : props.size * 0.75),
-      marginLeft: props => (props.round ? -props.size * 0.125 : null),
-      position: props => (props.round ? 'absolute' : 'relative'),
-      boxSizing: 'border-box',
-      left: 0,
-      border: props => (addBorder(props) ? `1px solid ${props.borderColor || palette.color.grayLightest}` : null),
-    },
-    roundFlagContainer: {
-      display: 'inline-block',
-      position: 'relative',
-      width: props => props.size * 0.75,
-      height: props => props.size * 0.75,
-      overflow: 'hidden',
-      borderRadius: '50%',
-    },
-  };
-};
+const Flag = props => {
+  /** Will be deprecated. */
+  if (typeof props.size === 'number') {
+    return <FlagDeprecated {...props} />;
+  }
 
-const Flag = ({ classes, className, style, countryCode, secondaryCountryCode, size, round, hideBorder, borderColor, ...rest }) => {
+  const { classes, className, style, countryCode, secondaryCountryCode, size, round, hideBorder, borderColor, ...rest } = props;
+
+  /** Will be deprecated. This is here just for backwards compatibility. */
+  const extendedStyle = {
+    ...style,
+    border: addBorder(props) ? `1px solid ${props.borderColor || color.grayLightest}` : null,
+  };
+
   if (secondaryCountryCode) {
     return (
       <CurrencyFlag
-        className={cn(classes.flagStyle, className, 'flag')}
-        style={style}
+        style={extendedStyle}
         size={size}
         primaryCC={countryCode.toLowerCase()}
         secondaryCC={secondaryCountryCode.toLowerCase()}
       />
     );
   }
-  const SvgFlag = flags[countryCode.toLowerCase()];
 
-  if (!SvgFlag) {
-    return null;
-  }
-
-  const flag = <SvgFlag className={cn(classes.flagStyle, className, 'flag')} style={style} {...omit(rest, 'theme')} />;
-
-  if (round) {
-    return <span className={classes.roundFlagContainer}>{flag}</span>;
-  }
-
-  return <div className={classes.container}>{flag}</div>;
+  return <SvgFlag round={round} size={size} countryCode={countryCode.toLowerCase()} style={style} {...omit(rest, 'theme')} />;
 };
 
 Flag.defaultProps = {
@@ -105,12 +78,17 @@ Flag.propTypes = {
   /** A valid 2-character country code */
   countryCode: PropTypes.oneOf(countryCodes),
   secondaryCountryCode: PropTypes.oneOf(countryCodes),
-  /** Unitless pixel value */
-  size: PropTypes.number,
+  size: PropTypes.oneOfType([
+    /** Unitless pixel value */
+    /** Will be deprecated. Size will be predefined and one of 'xs', 'sm', 'md', 'lg'. */
+    PropTypes.number,
+    PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+  ]),
   style: PropTypes.object,
   round: PropTypes.bool,
   hideBorder: PropTypes.bool,
+  /** Will be deprecated. borderColor can be passed together with `styles` object. */
   borderColor: PropTypes.string,
 };
 export { Flag as Component };
-export default injectSheet(styles)(Flag);
+export default Flag;

--- a/src/components/flag/flag.jsx
+++ b/src/components/flag/flag.jsx
@@ -73,7 +73,7 @@ const countryCodes = [
 ];
 
 Flag.propTypes = {
-  classes: PropTypes.object.isRequired,
+  classes: PropTypes.object,
   className: PropTypes.string,
   /** A valid 2-character country code */
   countryCode: PropTypes.oneOf(countryCodes),

--- a/src/components/flag/flag.md
+++ b/src/components/flag/flag.md
@@ -1,4 +1,4 @@
-Classic usage: single flag
+Classic usage: single flag numeric size
 
     const flags = require('./flags');
 
@@ -7,6 +7,7 @@ Classic usage: single flag
       textAlign: 'center',
       padding: 16
     };
+  
 
     <div>
       { Object.keys(flags.default).map(flag => (
@@ -17,7 +18,37 @@ Classic usage: single flag
       )) }
     </div>
 
-Rounded flags:
+Classic usage: single flag literal size
+
+    const flags = require('./flags');
+
+    const style = {
+      display: 'inline-block',
+      textAlign: 'center',
+      padding: 16
+    };
+
+    initialState = { size: 'md' };
+  
+    <div>
+      <span>Select size:  </span>
+      <select onChange={(event) => setState({ size: event.target.value })}>
+       <option>xs</option>
+       <option>sm</option>
+       <option selected>md</option>
+       <option>lg</option>
+     </select>
+     <div>
+      { Object.keys(flags.default).map(flag => (
+          <div key={ flag } style={ style }>
+            <Flag size={state.size} countryCode={ flag } />
+            <div style={{ fontSize: 12, fontFamily: '"Hack", monospace' }}>{ flag }</div>
+          </div>
+        )) }
+     </div>
+    </div>
+
+Rounded flags numeric size:
 
     const flags = require('./flags');
 
@@ -36,7 +67,39 @@ Rounded flags:
       )) }
     </div>
 
-Currencies:
+Rounded flags literal size:
+
+    const flags = require('./flags');
+
+    const style = {
+      display: 'inline-block',
+      textAlign: 'center',
+      padding: 16
+    };
+
+    initialState = { size: 'md' };
+
+    <div>
+      <div>
+        <span>Select size:  </span>
+        <select onChange={(event) => setState({ size: event.target.value })}>
+        <option>xs</option>
+        <option>sm</option>
+        <option selected>md</option>
+        <option>lg</option>
+      </select>
+     </div>
+     <div>
+      { Object.keys(flags.default).map(flag => (
+        <div key={ flag } style={ style }>
+          <Flag size={state.size} countryCode={ flag } round />
+          <div style={{ fontSize: 12, fontFamily: '"Hack", monospace' }}>{ flag }</div>
+        </div>
+      )) }
+      </div>
+    </div>
+
+Currencies numeric size:
 
     <div>
       <Flag size={64} countryCode="eu" secondaryCountryCode="dk" />
@@ -47,6 +110,32 @@ Currencies:
       <Flag size={64} countryCode="us" secondaryCountryCode="se" />
       <Flag size={64} countryCode="eu" secondaryCountryCode="us" />
       <Flag size={64} countryCode="eu" secondaryCountryCode="gb" />
+    </div>
+
+Currencies literal size:
+
+    initialState = { size: 'md' };
+
+    <div>
+      <div>
+        <span>Select size:  </span>
+        <select onChange={(event) => setState({ size: event.target.value })}>
+        <option>xs</option>
+        <option>sm</option>
+        <option selected>md</option>
+        <option>lg</option>
+      </select>
+     </div>
+     <div>
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="dk" />
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="no" />
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="se" />
+      <Flag size={state.size} countryCode="dk" secondaryCountryCode="se" />
+      <Flag size={state.size} countryCode="no" secondaryCountryCode="se" />
+      <Flag size={state.size} countryCode="us" secondaryCountryCode="se" />
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="us" />
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="gb" />
+     </div>
     </div>
 
 At the moment these are all the supported currency combinations, but we can easily create more.

--- a/src/components/flag/flag.md
+++ b/src/components/flag/flag.md
@@ -32,10 +32,10 @@ Classic usage: single flag literal size
   
     <div>
       <span>Select size:  </span>
-      <select onChange={(event) => setState({ size: event.target.value })}>
+      <select value='md' onChange={(event) => setState({ size: event.target.value })}>
        <option>xs</option>
        <option>sm</option>
-       <option selected>md</option>
+       <option>md</option>
        <option>lg</option>
      </select>
      <div>
@@ -82,10 +82,10 @@ Rounded flags literal size:
     <div>
       <div>
         <span>Select size:  </span>
-        <select onChange={(event) => setState({ size: event.target.value })}>
+        <select value='md' onChange={(event) => setState({ size: event.target.value })}>
         <option>xs</option>
         <option>sm</option>
-        <option selected>md</option>
+        <option>md</option>
         <option>lg</option>
       </select>
      </div>
@@ -119,22 +119,15 @@ Currencies literal size:
     <div>
       <div>
         <span>Select size:  </span>
-        <select onChange={(event) => setState({ size: event.target.value })}>
+        <select value='md' onChange={(event) => setState({ size: event.target.value })}>
         <option>xs</option>
         <option>sm</option>
-        <option selected>md</option>
+        <option>md</option>
         <option>lg</option>
       </select>
      </div>
      <div>
       <Flag size={state.size} countryCode="eu" secondaryCountryCode="dk" />
-      <Flag size={state.size} countryCode="eu" secondaryCountryCode="no" />
-      <Flag size={state.size} countryCode="eu" secondaryCountryCode="se" />
-      <Flag size={state.size} countryCode="dk" secondaryCountryCode="se" />
-      <Flag size={state.size} countryCode="no" secondaryCountryCode="se" />
-      <Flag size={state.size} countryCode="us" secondaryCountryCode="se" />
-      <Flag size={state.size} countryCode="eu" secondaryCountryCode="us" />
-      <Flag size={state.size} countryCode="eu" secondaryCountryCode="gb" />
      </div>
     </div>
 

--- a/src/components/flag/flag.md
+++ b/src/components/flag/flag.md
@@ -32,7 +32,7 @@ Classic usage: single flag literal size
   
     <div>
       <span>Select size:  </span>
-      <select value='md' onChange={(event) => setState({ size: event.target.value })}>
+      <select defaultValue='md' onChange={(event) => setState({ size: event.target.value })}>
        <option>xs</option>
        <option>sm</option>
        <option>md</option>
@@ -82,7 +82,7 @@ Rounded flags literal size:
     <div>
       <div>
         <span>Select size:  </span>
-        <select value='md' onChange={(event) => setState({ size: event.target.value })}>
+        <select defaultValue='md' onChange={(event) => setState({ size: event.target.value })}>
         <option>xs</option>
         <option>sm</option>
         <option>md</option>
@@ -119,7 +119,7 @@ Currencies literal size:
     <div>
       <div>
         <span>Select size:  </span>
-        <select value='md' onChange={(event) => setState({ size: event.target.value })}>
+        <select defaultValue='md' onChange={(event) => setState({ size: event.target.value })}>
         <option>xs</option>
         <option>sm</option>
         <option>md</option>
@@ -128,6 +128,13 @@ Currencies literal size:
      </div>
      <div>
       <Flag size={state.size} countryCode="eu" secondaryCountryCode="dk" />
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="no" />	
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="se" />	
+      <Flag size={state.size} countryCode="dk" secondaryCountryCode="se" />	
+      <Flag size={state.size} countryCode="no" secondaryCountryCode="se" />	
+      <Flag size={state.size} countryCode="us" secondaryCountryCode="se" />	
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="us" />	
+      <Flag size={state.size} countryCode="eu" secondaryCountryCode="gb" />
      </div>
     </div>
 

--- a/src/components/flag/flags/currencies.jsx
+++ b/src/components/flag/flags/currencies.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import flags from './';
 
-export default function CombinedFlag({ style, primaryCC, secondaryCC, size, ...rest }) {
+export default function CombinedFlag({ style, primaryCC, secondaryCC, ...rest }) {
   const usedStyle = Object.assign(
     {},
     {
@@ -65,5 +65,4 @@ CombinedFlag.propTypes = {
   style: PropTypes.object,
   primaryCC: PropTypes.string,
   secondaryCC: PropTypes.string,
-  size: PropTypes.number,
 };

--- a/src/components/flag/flags/currency-flag.jsx
+++ b/src/components/flag/flags/currency-flag.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import injectSheet from 'react-jss';
 import cn from 'classnames';
 import CurrencyFlag from './currencies';
+import omit from '../../../utilities/omit';
 import styles from './styles';
 
 const Flag = props => {
@@ -10,7 +11,7 @@ const Flag = props => {
 
   return (
     <CurrencyFlag
-      {...props}
+      {...omit(props, 'round')}
       className={cn(className, classes.common, classes[size], {
         [classes[`rounded${size.toUpperCase()}`]]: round,
       })}

--- a/src/components/flag/flags/currency-flag.jsx
+++ b/src/components/flag/flags/currency-flag.jsx
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import injectSheet from 'react-jss';
+import cn from 'classnames';
+import CurrencyFlag from './currencies';
+import styles from './styles';
+
+const Flag = props => {
+  const { size, className, classes, round } = props;
+
+  return (
+    <CurrencyFlag
+      {...props}
+      className={cn(className, classes.common, classes[size], {
+        [classes[`rounded${size.toUpperCase()}`]]: round,
+      })}
+    />
+  );
+};
+
+Flag.defaultProps = {
+  size: 'sm',
+  round: false,
+};
+
+Flag.propTypes = {
+  classes: PropTypes.object.isRequired,
+  className: PropTypes.string,
+  round: PropTypes.bool,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+};
+
+export { Flag as Component };
+export default injectSheet(styles)(Flag);

--- a/src/components/flag/flags/index.js
+++ b/src/components/flag/flags/index.js
@@ -12,4 +12,8 @@ import us from './us';
 import jp from './jp';
 import cn from './cn';
 
+import SvgFlag from './svg-flag';
+import CurrencyFlag from './currency-flag';
+
 export default { ca, de, eu, fr, ru, gb, dk, fi, no, se, us, jp, cn };
+export { CurrencyFlag, SvgFlag };

--- a/src/components/flag/flags/styles.js
+++ b/src/components/flag/flags/styles.js
@@ -1,0 +1,77 @@
+const sizes = {
+  xs: {
+    width: 16,
+    height: 12,
+  },
+  sm: {
+    width: 32,
+    height: 24,
+  },
+  md: {
+    width: 64,
+    height: 48,
+  },
+  lg: {
+    width: 128,
+    height: 96,
+  },
+};
+
+const rounded = {
+  roundedXS: {
+    marginLeft: -sizes.xs.width * 0.125,
+    position: 'absolute',
+  },
+  roundedSM: {
+    marginLeft: -sizes.sm.width * 0.125,
+    position: 'absolute',
+  },
+  roundedMD: {
+    marginLeft: -sizes.md.width * 0.125,
+    position: 'absolute',
+  },
+  roundedLG: {
+    marginLeft: -sizes.lg.width * 0.125,
+    position: 'absolute',
+  },
+};
+
+const roundedContainer = {
+  roundedContainer: {
+    display: 'inline-block',
+    position: 'relative',
+    overflow: 'hidden',
+    borderRadius: '50%',
+  },
+  roundedContainerXS: {
+    width: sizes.xs.width * 0.75,
+    height: sizes.xs.width * 0.75,
+  },
+  roundedContainerSM: {
+    width: sizes.sm.width * 0.75,
+    height: sizes.sm.width * 0.75,
+  },
+  roundedContainerMD: {
+    width: sizes.md.width * 0.75,
+    height: sizes.md.width * 0.75,
+  },
+  roundedContainerLG: {
+    width: sizes.lg.width * 0.75,
+    height: sizes.lg.width * 0.75,
+  },
+};
+
+export default {
+  common: {
+    display: 'block',
+    boxSizing: 'border-box',
+    position: 'relative',
+    left: 0,
+  },
+  container: {
+    display: 'inline-block',
+  },
+  ...sizes,
+  ...rounded,
+  ...roundedContainer,
+};

--- a/src/components/flag/flags/svg-flag.jsx
+++ b/src/components/flag/flags/svg-flag.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import injectSheet from 'react-jss';
 import cn from 'classnames';
 import flags from '../flags';
+import omit from '../../../utilities/omit';
 import styles from './styles';
 
 const SvgFlag = props => {
@@ -17,14 +18,17 @@ const SvgFlag = props => {
   if (round) {
     return (
       <span className={cn(classes.roundedContainer, classes[`roundedContainer${size.toUpperCase()}`])}>
-        <Flag {...props} className={cn(className, classes.common, classes[size], classes[`rounded${size.toUpperCase()}`])} />
+        <Flag
+          {...omit(props, 'countryCode', 'round')}
+          className={cn(className, classes.common, classes[size], classes[`rounded${size.toUpperCase()}`])}
+        />
       </span>
     );
   }
 
   return (
     <span className={classes.container}>
-      <Flag {...props} className={cn(className, classes.common, classes[size])} />
+      <Flag {...omit(props, 'countryCode', 'round')} className={cn(className, classes.common, classes[size])} />
     </span>
   );
 };

--- a/src/components/flag/flags/svg-flag.jsx
+++ b/src/components/flag/flags/svg-flag.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import injectSheet from 'react-jss';
+import cn from 'classnames';
+import flags from '../flags';
+import styles from './styles';
+
+const SvgFlag = props => {
+  const Flag = flags[props.countryCode];
+
+  if (!Flag) {
+    return null;
+  }
+
+  const { size, className, classes, round } = props;
+
+  if (round) {
+    return (
+      <span className={cn(classes.roundedContainer, classes[`roundedContainer${size.toUpperCase()}`])}>
+        <Flag {...props} className={cn(className, classes.common, classes[size], classes[`rounded${size.toUpperCase()}`])} />
+      </span>
+    );
+  }
+
+  return (
+    <span className={classes.container}>
+      <Flag {...props} className={cn(className, classes.common, classes[size])} />
+    </span>
+  );
+};
+
+SvgFlag.defaultProps = {
+  size: 'sm',
+  round: false,
+};
+
+SvgFlag.propTypes = {
+  classes: PropTypes.object.isRequired,
+  countryCode: PropTypes.string.isRequired,
+  className: PropTypes.string,
+  size: PropTypes.oneOf(['xs', 'sm', 'md', 'lg']),
+  round: PropTypes.bool,
+};
+
+export { SvgFlag as Component };
+export default injectSheet(styles)(SvgFlag);

--- a/test/components/flag/currency-flag.test.js
+++ b/test/components/flag/currency-flag.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { Component as CurrencyFlag } from '../../../src/components/flag/flags/currency-flag';
+import styles from '../../../src/components/flag/flags/styles';
+import { mockClasses } from '../../../src/';
+
+const classes = mockClasses(styles);
+const shallowComponent = props => shallow(<CurrencyFlag classes={classes} countryCode="se" {...props} />);
+
+describe('<CurrencyFlag />', () => {
+  it(`should have common and size classes`, () => {
+    const wrapper = shallowComponent();
+
+    expect(wrapper.hasClass('common')).to.equal(true);
+    expect(wrapper.hasClass('sm')).to.equal(true);
+  });
+
+  it(`should have rounded class`, () => {
+    const wrapper = shallowComponent({ round: true, size: 'lg' });
+
+    expect(wrapper.hasClass('roundedLG')).to.equal(true);
+  });
+});

--- a/test/components/flag/flag.test.js
+++ b/test/components/flag/flag.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { expect } from 'chai';
-import { Component as Flag, styles } from '../../../src/components/flag/flag';
+import { Component as Flag, styles } from '../../../src/components/flag/flag-deprecated';
 import { mockClasses } from '../../../src/';
 import { createTheme } from '../../../src/styles';
 

--- a/test/components/flag/svg-flag.test.js
+++ b/test/components/flag/svg-flag.test.js
@@ -1,0 +1,41 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import { expect } from 'chai';
+import { Component as SvgFlag } from '../../../src/components/flag/flags/svg-flag';
+import styles from '../../../src/components/flag/flags/styles';
+import { mockClasses } from '../../../src/';
+
+const classes = mockClasses(styles);
+const shallowComponent = props => shallow(<SvgFlag classes={classes} countryCode="se" {...props} />);
+
+describe('<SvgFlag />', () => {
+  it(`has common class`, () => {
+    const wrapper = shallowComponent()
+      .children()
+      .first();
+
+    expect(wrapper.hasClass('common')).to.equal(true);
+  });
+
+  it('renders small flag by default', () => {
+    const wrapper = shallowComponent()
+      .children()
+      .first();
+
+    expect(wrapper.hasClass('sm')).to.equal(true);
+  });
+
+  it(`rounded container has roundedContainer classes`, () => {
+    const wrapper = shallowComponent({ round: true, size: 'md' });
+
+    expect(wrapper.hasClass('roundedContainer')).to.equal(true);
+    expect(wrapper.hasClass('roundedContainerMD')).to.equal(true);
+  });
+
+  it(`rounded medium flag has roundedMD class`, () => {
+    const wrapper = shallowComponent({ round: true, size: 'md' });
+    const Flag = wrapper.children().first();
+
+    expect(Flag.hasClass('roundedMD')).to.equal(true);
+  });
+});


### PR DESCRIPTION
Since `Flag`'s component's styles are generated dynamically based on props, for each flag a separate stylesheet was being created by `jss` and injected into `<head />`. This can cause performance issues when there are many flags rendered on page.

Instead of accepting `size` as a numeric value, change was made for size to be one of values: `xs`, `sm`, `md`, `lg` which corresponts to numeric values `16`, `32`, `64`, `128`.

Changes done:

`flag-deprecated.jsx` is created, which is a copy of old `flag.jsx` for preserving backwards compatibility.

`flag.jsx` was modified to get rid of dynamically generated styles. Instead it renders newly created wrappers `currency-flag.jsx` and `svg-flag.jsx` which themselves have static styles.