### PR TITLE
fix: resolve styling bug in safari

### DIFF
--- a/src/components/show-more/show-more-styles.js
+++ b/src/components/show-more/show-more-styles.js
@@ -9,7 +9,7 @@ export default () => ({
       position: 'absolute',
       left: 0,
       bottom: 0,
-      background: ({ backgroundColor }) => `linear-gradient(transparent, ${backgroundColor})`,
+      background: ({ backgroundColor }) => `linear-gradient(rgba(255,255,255,0), ${backgroundColor})`,
     },
     margin: 0,
   },


### PR DESCRIPTION
Safari has a quirk when rendering transparent in linear-gradients causing the gradient to darken instead. Using rgba resolves that issue.
Before: 
<img width="252" alt="before" src="https://user-images.githubusercontent.com/1714862/48117836-ba037680-e26a-11e8-8c4d-daad8c7c914a.png">
After:
<img width="256" alt="after" src="https://user-images.githubusercontent.com/1714862/48117857-cc7db000-e26a-11e8-948c-7b205af46ce3.png">

Verified that it looks good in: 
Safari 12
Chrome 70
Firefox 63
IE 11
Edge 42