### PR TITLE
Empty table headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "in-publish": "^2.0.0",
     "istanbul-instrumenter-loader": "^2.0.0",
     "jsdom": "^9.11.0",
-    "lint-staged": "^7.0.0",
+    "lint-staged": "^7.2.0",
     "lodash.camelcase": "^4.3.0",
     "mocha": "^3.2.0",
     "mocha-webpack": "^0.7.0",

--- a/src/components/table-cell/table-cell.jsx
+++ b/src/components/table-cell/table-cell.jsx
@@ -64,7 +64,7 @@ function TableCell({
   return (
     <Tag {...rest} className={usedClassName} style={style}>
       <div className={classNames({ [classes.child]: !unstyledChild }, { [classes.ellipsis]: ellipsis })} data-title={title}>
-        {children}
+        {children || '\u00a0'}
       </div>
     </Tag>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4989,7 +4989,7 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-lint-staged@^7.0.0:
+lint-staged@^7.2.0:
   version "7.3.0"
   resolved "https://registry.npmjs.org/lint-staged/-/lint-staged-7.3.0.tgz#90ff33e5ca61ed3dbac35b6f6502dbefdc0db58d"
   integrity sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==


### PR DESCRIPTION
## Issue
In IE and Edge the header border on the tables does not render correctly if the `<th>` is empty. 
Expected:
![Expected](https://user-images.githubusercontent.com/1714862/49289599-8f40c280-f4a4-11e8-813c-80d1e0bf3422.png)
Actual:
![Actual](https://user-images.githubusercontent.com/1714862/49290172-86e98700-f4a6-11e8-89e3-10318f21b5a1.png)


## Background 
This is caused by a parent component having `display: flex` that Edge picks up and incorrectly applies it to the` div` in the `th`. I have not been able to override this effect. 

## Fix
The fix in this PR injects a white space in any table cell that would otherwise be empty. Hence, render the table correctly. 
