### PR TITLE
fix(TableContentWrapper): add possibility to extend Td props

### DIFF
--- a/src/components/table-content-wrapper/shapes.js
+++ b/src/components/table-content-wrapper/shapes.js
@@ -11,6 +11,7 @@ export const colShape = PropTypes.shape({
   align: PropTypes.string,
   type: PropTypes.string,
   padding: PropTypes.bool,
+  tdProps: PropTypes.shape({}),
   responsiveProps: PropTypes.shape({
     flexOrder: PropTypes.number,
     flexBasisMobile: PropTypes.number,

--- a/src/components/table-content-wrapper/table-body/table-body-row/table-body-row.jsx
+++ b/src/components/table-content-wrapper/table-body/table-body-row/table-body-row.jsx
@@ -64,6 +64,7 @@ class TableBodyRow extends Component {
             title={col.headerLabel}
             collapsed={!col.firstMobileRow && collapsed}
             onClick={col.firstMobileRow && this.toggleExpandedRow}
+            {...col.tdProps}
             {...convertBasis(col.responsiveProps, spacers)}
           >
             {renderTd({ col, rowData })}


### PR DESCRIPTION
Allow adding 

  tdProps: {
    unstyledChild: true,
    ellipsis: false,
  },

to cols definition