### PR TITLE
fix: add height 100% to th and th:after to fix border issue in edge

### DIFF
--- a/src/components/table-cell/table-cell.jsx
+++ b/src/components/table-cell/table-cell.jsx
@@ -57,6 +57,7 @@ function TableCell({
     width: `${width}${typeof width === 'number' ? '%' : ''}`,
     flexBasis: `${flexBasisMobile}${typeof flexBasisMobile === 'number' ? '%' : ''}`,
     order: `${flexOrder}`,
+    height: '100%',
     ...styleProp,
   };
 

--- a/src/components/thead/thead-styles.jsx
+++ b/src/components/thead/thead-styles.jsx
@@ -34,6 +34,7 @@ const normal = ({ mixins, typography, palette: { color } }) => ({
       position: 'absolute',
       left: 0,
       bottom: 0,
+      height: '100%',
       width: '100%',
       borderBottom: `2px solid ${color.grayDarker}`,
       '@media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: none)': {


### PR DESCRIPTION
Fixing issue in edge where the bottom border on Th elements went all over the place.
<img width="678" alt="screenshot 2019-01-15 at 11 42 17" src="https://user-images.githubusercontent.com/1640968/51175435-a6a00780-18ba-11e9-999d-4789cb1194f2.png">
