### PR TITLE
ci(travis): bring back ci on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,12 @@ cache:
 
 jobs:
   include:
-    - stage: coverage
+    - stage: test
       node_js:
         - 10
         - 8
-      script:    
+      script:
+        - npm run lint
         - npm run coverage
     - stage: release
       node_js: 10
@@ -31,5 +32,5 @@ jobs:
       if: (NOT type IN (pull_request)) AND (branch = master)
 
 stages:
-  - name: coverage
+  - name: test
   - name: release

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ before_install:
 
 install: yarn install --ignore-engines
 
-branches:
-  only:
-    - "master"
-
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
CI on all branches, and linting in CI. Closes #528

So before, we only ran CI on PRs because we got "double builds" for PRs otherwise. See here for why that's actually desirable https://docs.travis-ci.com/user/pull-requests/#double-builds-on-pull-requests, as me, @iamstarkov and @Dhq found out.