### PR TITLE
ci: build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ jobs:
       script:
         - npm run lint
         - npm run coverage
+        - npm run babel:esm
+        - npm run build:docs
     - stage: release
       node_js: 10
       script:


### PR DESCRIPTION
Build docs and babel in ci. @iamstarkov and I talked about this, needed for renovate to ensure that nothing crashes from a PR.