### PR TITLE
chore: fix deprecated husky configs and cleanup package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,20 +51,6 @@
       "git add"
     ]
   },
-  "nyc": {
-    "extension": [
-      ".js",
-      ".jsx"
-    ],
-    "all": true,
-    "instrument": false,
-    "sourceMap": false,
-    "reporter": [
-      "lcov",
-      "text-summary",
-      "text"
-    ]
-  },
   "author": "Gustaf Zetterlund <gustaf.zetterlund@nordnet.se>",
   "repository": "nordnet/nordnet-ui-kit",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -6,9 +6,7 @@
   "module": "dist/esm",
   "sideEffects": false,
   "scripts": {
-    "precommit": "lint-staged",
     "commit": "git-cz",
-    "commitmsg": "validate-commit-msg",
     "clean": "rimraf dist",
     "dev": "run-s start",
     "build": "run-s clean babel:*",
@@ -20,7 +18,6 @@
     "test": "jest",
     "tdd": "jest --watch",
     "coverage": "jest --coverage --coverageReporters=text-lcov | coveralls",
-    "prepush": "run-p lint test",
     "prepublish": "in-publish && run-s lint test build || not-in-publish",
     "start": "styleguidist server --colors",
     "now-build": "npm run build:docs",
@@ -137,5 +134,12 @@
     "sinon": "7.2.3",
     "validate-commit-msg": "2.14.0",
     "webpack": "4.29.3"
+  },
+  "husky": {
+    "hooks": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": "lint-staged",
+      "pre-push": "run-p lint test"
+    }
   }
 }


### PR DESCRIPTION
I got some husky warnings on my machine, turns out that they have changed how it's supposed to be configured https://github.com/typicode/husky#upgrading-from-014 But thankfully they had a `./node_modules/.bin/husky-upgrade` so this is just a run of that and now committing and pushing works without warnings.