### PR TITLE
chore: travis and renovate fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,10 @@ cache:
 
 jobs:
   include:
-    - stage: test
+    - stage: test-and-build
       script:
         - npm run lint
         - npm run coverage
-
-    - stage: build
-      script:
         - npm run build
         - npm run build:docs
 
@@ -36,6 +33,5 @@ jobs:
       if: (NOT type IN (pull_request)) AND (branch = master)
 
 stages:
-  - name: test
-  - name: build
+  - name: test-and-build
   - name: release

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint --ext=.jsx --ext=.js src",
     "test": "jest",
     "tdd": "jest --watch",
-    "coverage": "jest --coverage --coverageReporters=text-lcov | coveralls",
+    "coverage": "npm run test",
     "prepublish": "in-publish && run-s lint test build || not-in-publish",
     "start": "styleguidist server --colors",
     "now-build": "npm run build:docs",

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,13 @@
 {
   "extends": [
     "config:base",
-    ":pinOnlyDevDependencies",
-    "group:allNonMajor"
+    ":pinOnlyDevDependencies"
   ],
-  "ignoreDeps": ["color"]
+  "ignoreDeps": ["color"],
+  "packageRules": [
+    {
+      "depTypeList":  ["devDependencies"],
+      "schedule": "before 3am on Monday"
+    }
+  ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "extends": [
     "config:base",
-    ":pinOnlyDevDependencies"
+    ":pinOnlyDevDependencies",
+    "group:allNonMajor"
   ],
   "ignoreDeps": ["color"]
 }


### PR DESCRIPTION
* Reduces the number of stages in travis, to avoid having to wait for environments to spin up twice for test and build, which can be done in the same environment.
* Disables coveralls, which has started to fail us. The problem is, as discussed on their side. Let's find a suitable alternative when we have time. I'm open for in some way *trying* to run coveralls, but not failing with non-zero exit code if coveralls fails (on their side), thus having to retrigger the whole build.
* groups all non-major renovate bumps in the same PR, to avoid being spammed with PRs for dev dependencies.