### PR TITLE
fix(editable-input): adjust positioning of buttons per mixin breakpoint

### DIFF
--- a/src/components/editable-input/editable-input-styles.jsx
+++ b/src/components/editable-input/editable-input-styles.jsx
@@ -5,9 +5,13 @@ export default theme => ({
     justifyContent: 'flex-end',
   },
   isEditing: {
-    flexWrap: 'wrap',
+    flexDirection: 'column',
+    alignItems: 'center',
     [theme.mixins.media('md')]: {
-      flexWrap: 'nowrap',
+      alignItems: 'flex-end',
+    },
+    [theme.mixins.media('lg')]: {
+      flexDirection: 'row',
     },
   },
   form: {
@@ -39,9 +43,11 @@ export default theme => ({
   buttons: {
     display: 'flex',
     flexShrink: 0,
-    alignSelf: 'center',
+    [theme.mixins.media('lg')]: {
+      alignSelf: 'flex-start',
+    },
   },
   buttonEdit: {
-    alignSelf: 'center',
+    alignSelf: 'flex-start',
   },
 });


### PR DESCRIPTION
The desired result is to get the following behaviour on our pages:

At 'lg' and wider, use the full width:
![Screenshot 2019-03-18 at 17 39 24](https://user-images.githubusercontent.com/13475700/54546888-ed86a800-49a4-11e9-84a2-589623754059.png)

Between 'md' and 'lg', have the buttons on the next row, aligned to the right:
![Screenshot 2019-03-18 at 17 39 37](https://user-images.githubusercontent.com/13475700/54546936-0a22e000-49a5-11e9-84be-87f019a4961f.png)

And on smaller view widths, most importantly mobile, have the input and buttons on two rows, buttons centered:
![Screenshot 2019-03-18 at 17 39 52](https://user-images.githubusercontent.com/13475700/54546969-1c9d1980-49a5-11e9-831a-be647fa6523e.png)
