### PR TITLE
fix: font stack

### DIFF
--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -8,7 +8,8 @@ const WEIGHTS = {
 
 export default function createTypography() {
   const ifSmallDevice = (smallFontSize, largeFontSize) => ({
-    fontFamily: '"Nordnet Sans Mono", "Open Sans", sans',
+    fontFamily:
+      '"Nordnet Sans Mono", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
     fontSize: smallFontSize,
     letterSpacing: 'normal',
     [`@media only screen and (min-width: ${SMALL_DEVICE}px)`]: {


### PR DESCRIPTION
`sans` should be `sans-serif`, and I replaced Open Sans with a [native font stack](https://getbootstrap.com/docs/4.0/content/reboot/#native-font-stack) as fallback.