### PR TITLE
fix: make mobile actually get mobile styles

### DIFF
--- a/src/styles/breakpoints.js
+++ b/src/styles/breakpoints.js
@@ -1,4 +1,4 @@
-const breakpoints = {
+export const breakpoints = {
   // The grid is mobile first so xs is the default, hence no breakpoint
   xs: false,
   sm: 768,

--- a/src/styles/typography.js
+++ b/src/styles/typography.js
@@ -1,4 +1,6 @@
-const SMALL_DEVICE = 360;
+import { breakpoints } from './breakpoints';
+
+const SMALL_DEVICE = breakpoints.sm;
 
 const WEIGHTS = {
   regular: 400,


### PR DESCRIPTION
Before we had mobile typography styles for all devices if their viewports is less than 360px, which is almost no devices. Instead mobile styles will now be for everything under 768px viewport.